### PR TITLE
Feature/#47 프로필정보등록공통컴포넌트

### DIFF
--- a/src/app/_components/PostProfile.tsx
+++ b/src/app/_components/PostProfile.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import Button from '@/app/_components/Button';
+
+interface PostProps {
+  isExist: boolean;
+  type: keyof typeof POST_TYPE_CONFIG;
+}
+
+const POST_TYPE_CONFIG = {
+  myStore: {
+    title: '내 가게',
+    navigateTo: '',
+    buttonLabel: '가게 등록하기',
+    description: '내 가게를 소개하고 공고도 등록해 보세요.',
+  },
+  announcement: {
+    title: '등록된 공고',
+    navigateTo: '',
+    buttonLabel: '공고 등록하기',
+    description: '공고를 등록해 보세요.',
+  },
+  profile: {
+    title: '내 프로필',
+    navigateTo: '',
+    buttonLabel: '내 프로필 등록하기',
+    description: '내 프로필을 등록하고 원하는 가게에 지원해 보세요.',
+  },
+  application: {
+    title: '신청 내역',
+    navigateTo: '',
+    buttonLabel: '공고 보러가기',
+    description: '아직 신청 내역이 없어요.',
+  },
+} as const;
+
+const PostProfile = ({ isExist, type }: PostProps) => {
+  if (isExist) return null;
+
+  const { title, navigateTo, buttonLabel, description } =
+    POST_TYPE_CONFIG[type];
+
+  return (
+    <div className='flex justify-center items-center'>
+      <div className='lg:w-[1440px] md:w-[744px] w-[375px] lg:h-[395px] md:h-[395px] h-[315px] px-3 py-10'>
+        <div className='mx-auto text-2xl font-bold mb-4 text-left lg:w-[965px] md:w-[680px] sm:w-[351px]'>
+          {title}
+        </div>
+        <div
+          className='flex flex-col items-center justify-center border border-gray-200 rounded-[10px] 
+                          lg:w-[965px] lg:h-[217px] 
+                          md:w-[680px] md:h-[217px] 
+                          sm:w-[351px] sm:h-[195px] 
+                          mx-auto'>
+          <p className='text-gray-500 mb-6 text-sm md:text-base text-center'>
+            {description}
+          </p>
+          <Button
+            size='lg'
+            onClick={() => {
+              window.location.href = navigateTo;
+            }}>
+            {buttonLabel}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default PostProfile;

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -49,7 +49,6 @@
   border-radius: 40px;
 }
 
-/* CSS 파일이나 Global Styles에 추가 */
 input[type='number'].no-spinner::-webkit-outer-spin-button,
 input[type='number'].no-spinner::-webkit-inner-spin-button {
   -webkit-appearance: none;


### PR DESCRIPTION
### 이슈 번호

close #47 

### 작업 사항 요약

PostProfile 컴포넌트 구현

- POST_TYPE_CONFIG를 사용하여 type에 따라 동적으로 UI를 렌더링하도록 설정.
  - isExist 값이 true일 경우 컴포넌트를 렌더링하지 않도록 예외 처리.

POST_TYPE_CONFIG 설정값 표
Key | title | navigateTo | buttonLabel | description
-- | -- | -- | -- | --
myStore | 내 가게 | '' | 가게 등록하기 | 내 가게를 소개하고 공고도 등록해 보세요.
announcement | 등록된 공고 | '' | 공고 등록하기 | 공고를 등록해 보세요.
profile | 내 프로필 | '' | 내 프로필 등록하기 | 내 프로필을 등록하고 원하는 가게에 지원해 보세요.
application | 신청 내역 | '' | 공고 보러가기 | 아직 신청 내역이 없어요.
 - 해당 내용은 인지만 하시고 type프롭에 key값만 넣으시면 됩니다.

- 반응형 디자인 적용
  - 화면 너비에 따라 레이아웃과 높이를 동적으로 조정.
    - lg (1440px 이상): 컨테이너 1440x395, 내부 박스 965x217.
    - md (744px 이상): 컨테이너 744x395, 내부 박스 680x217.
    - sm (375px 이상): 컨테이너 375x315, 내부 박스 351x195.

- 컴포넌트 구조
  - 타이틀, 설명, 버튼을 포함한 레이아웃을 구성.
  - 타이틀과 내부 콘텐츠의 가로 위치가 자연스럽게 맞춰지도록 스타일링.
  
- 네비게이션 기능 추가
  - 버튼 클릭 시 navigateTo 값에 맞게 페이지 이동 처리.

- 유지보수 및 재사용성 강화
  - 설정값(POST_TYPE_CONFIG)을 객체로 분리하여 확장성을 제공.
  - type에 따라 제목, 설명, 버튼 레이블 등을 재사용 가능하도록 설정.

### 작업 결과

![image](https://github.com/user-attachments/assets/bbc8628d-00c9-47bb-bdc5-1b6ab8c89497)
![image](https://github.com/user-attachments/assets/e4efa7c7-3db8-4f5b-afec-7a5b98f7fcd3)
![image](https://github.com/user-attachments/assets/446e8893-06e5-4fa2-8788-3c2151fb928d)


