### PR TITLE
Feature/#57 공통컴포넌트타입리팩토링

### DIFF
--- a/src/app/_components/Dropdown.tsx
+++ b/src/app/_components/Dropdown.tsx
@@ -2,21 +2,21 @@ import clsx from 'clsx';
 import Image from 'next/image';
 import { useEffect, useRef, useState } from 'react';
 
-interface DropdownProps {
-  options: string[];
-  value?: string;
-  onChange?: (value: string) => void;
+interface DropdownProps<T = string> {
+  options: T[];
+  value?: T;
+  onChange?: (value: T) => void;
   className?: string;
   placeholder?: string;
 }
 
-export const Dropdown = ({
+export const Dropdown = <T,>({
   options,
   value,
   onChange,
   className,
   placeholder = '선택',
-}: DropdownProps) => {
+}: DropdownProps<T>) => {
   const [isOpen, setIsOpen] = useState(false);
   const dropdownRef = useRef<HTMLDivElement>(null);
 
@@ -38,7 +38,7 @@ export const Dropdown = ({
 
   const toggleDropdown = () => setIsOpen((prev) => !prev);
 
-  const handleOptionClick = (option: string) => {
+  const handleOptionClick = (option: T) => {
     onChange?.(option);
     setIsOpen(false);
   };
@@ -51,11 +51,11 @@ export const Dropdown = ({
           'w-full flex items-center justify-between bg-white border border-gray-300 rounded py-4 px-5 text-left',
           value ? 'text-black' : 'text-gray-400',
         )}>
-        {value || placeholder}
+        {value !== undefined ? String(value) : placeholder}
         <div className={clsx('transform', { 'rotate-180': isOpen })}>
           <Image
             src={'/image/dropdown-triangle.svg'}
-            alt="드롭다운 화살표"
+            alt='드롭다운 화살표'
             width={16}
             height={16}
             priority
@@ -68,15 +68,15 @@ export const Dropdown = ({
           className={clsx(
             'custom-scrollbar absolute z-2 w-full bg-white border rounded mt-2 max-h-[230px] overflow-auto',
           )}>
-          {options.map((option) => (
+          {options.map((option, index) => (
             <li
-              key={option}
+              key={index}
               className={clsx(
                 'py-3 text-14 text-black text-center cursor-pointer border-b',
                 'hover:bg-blue-10 border-gray-200',
               )}
               onClick={() => handleOptionClick(option)}>
-              {option}
+              {String(option)}
             </li>
           ))}
         </ul>

--- a/src/app/_components/Modal.tsx
+++ b/src/app/_components/Modal.tsx
@@ -10,7 +10,7 @@ interface ModalProps {
   content: React.ReactNode;
   onClose: () => void;
   onConfirm?: () => void;
-  questionVariant?: 'cancel' | 'approve' | 'reject';
+  questionType?: 'cancel' | 'approve' | 'reject';
 }
 
 export const Modal = ({
@@ -19,7 +19,7 @@ export const Modal = ({
   content,
   onClose,
   onConfirm,
-  questionVariant = 'cancel',
+  questionType = 'cancel',
 }: ModalProps) => {
   // 모달창이 켜져있을 경우 스크롤 방지
   useEffect(() => {
@@ -37,7 +37,7 @@ export const Modal = ({
 
   const config =
     type === 'question'
-      ? modalConfig.question(questionVariant)
+      ? modalConfig.question(questionType)
       : modalConfig[type];
 
   const { icon, responsiveClass, contentStyle, buttonPosition, buttons } =


### PR DESCRIPTION
### 이슈 번호

close #57 

### 작업 사항 요약
- **Dropdown** 컴포넌트 기본 타입을 string으로 지정하였고, options Props를 string 배열이 아닌 **제네릭으로 변경**하여 다른 타입의 배열도 올 수 있게 하였습니다. 
- **Index** 컴포넌트는 **타입 수정사항 없습니다.**
- **Modal** 컴포넌트는 **타입 수정 없습니다.** 다만, **props 이름**만 **명시적**으로 **변경**하였습니다.
- 아래 사진은 숫자 배열의 Dropdown도 오류 없이 잘 구현된 모습입니다. 

### 작업 결과
![dropdown test](https://github.com/user-attachments/assets/1e336d63-4133-44f0-bb2e-cd6d5a6e488c)

