### PR TITLE
API, Context 셋팅

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "axios": "^1.7.9",
         "clsx": "^2.1.1",
+        "jwt-decode": "^4.0.0",
         "next": "15.1.0",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
@@ -3550,6 +3551,14 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "axios": "^1.7.9",
     "clsx": "^2.1.1",
+    "jwt-decode": "^4.0.0",
     "next": "15.1.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",

--- a/src/app/_api/api.ts
+++ b/src/app/_api/api.ts
@@ -1,3 +1,0 @@
-import axios from 'axios';
-
-export const api = () => {};

--- a/src/app/_api/instance.ts
+++ b/src/app/_api/instance.ts
@@ -1,0 +1,36 @@
+import axios, { AxiosInstance } from 'axios';
+import { useAuth } from '../_hooks/useAuth';
+
+const BASE_URL = process.env.NEXT_PUBLIC_API_BASE_URL;
+
+const instance: AxiosInstance = axios.create({
+  baseURL: BASE_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+instance.interceptors.request.use(
+  (config) => {
+    const { token } = useAuth();
+
+    if (token && config.headers?.requiresToken) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    delete config.headers?.requiresToken;
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  },
+);
+
+instance.interceptors.response.use(
+  (response) => response.data,
+  (error) => {
+    console.error('API Error:', error.response || error.message);
+    return Promise.reject(error.response || error.message);
+  },
+);
+
+export default instance;

--- a/src/app/_context/AppContext.tsx
+++ b/src/app/_context/AppContext.tsx
@@ -1,0 +1,8 @@
+import React from 'react';
+import { AuthProvider } from './AuthContext';
+
+export const AppProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  return <AuthProvider>{children}</AuthProvider>;
+};

--- a/src/app/_context/AuthContext.tsx
+++ b/src/app/_context/AuthContext.tsx
@@ -1,0 +1,61 @@
+import React, { createContext, useState } from 'react';
+import { jwtDecode, JwtPayload } from 'jwt-decode';
+
+interface DecodedToken extends JwtPayload {
+  userId: string;
+  email: string;
+  role: 'employer' | 'employee';
+}
+
+interface User {
+  id: string;
+  email: string;
+  type: 'employer' | 'employee';
+  name?: string;
+  phone?: string;
+  address?: string;
+  bio?: string;
+}
+
+interface AuthContextProps {
+  token: string | null;
+  user: User | null;
+  login: (data: { token: string; user: User }) => void;
+  logout: () => void;
+}
+
+export const AuthContext = createContext<AuthContextProps | undefined>(
+  undefined,
+);
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [token, setToken] = useState<string | null>(null);
+  const [user, setUser] = useState<User | null>(null);
+
+  const login = (data: { token: string; user: User }) => {
+    const decoded = jwtDecode<DecodedToken>(data.token);
+
+    setToken(data.token);
+    // 디코딩 데이터 부분은 추후에 디코딩해보고 변경될수있습니다.
+    setUser({
+      ...data.user,
+      id: decoded.userId,
+      email: decoded.email,
+      type: decoded.role,
+    });
+  };
+
+  //로그아웃 로직도 추후 변경될수있습니다 일단 임시입니다.
+  const logout = () => {
+    setToken(null);
+    setUser(null);
+  };
+
+  return (
+    <AuthContext.Provider value={{ token, user, login, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/src/app/_hooks/useAuth.ts
+++ b/src/app/_hooks/useAuth.ts
@@ -1,0 +1,10 @@
+import { useContext } from 'react';
+import { AuthContext } from '../_context/AuthContext';
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('어흥');
+  }
+  return context;
+};

--- a/src/app/_hooks/useHook.ts
+++ b/src/app/_hooks/useHook.ts
@@ -1,1 +1,0 @@
-export const useHook = () => {};

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,4 +1,5 @@
-import "./globals.css";
+import { AppProvider } from './_context/AppContext';
+import './globals.css';
 
 export default function RootLayout({
   children,
@@ -6,8 +7,10 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="ko">
-      <body>{children}</body>
+    <html lang='ko'>
+      <body>
+        <AppProvider>{children}</AppProvider>
+      </body>
     </html>
   );
 }


### PR DESCRIPTION
### 이슈 번호

close #67 

### 작업 사항 요약

1. API의 기본 인스턴스 만들었습니다.
앞으로 모든 API에서 사용될 기본 인스턴스 입니다.

2. Context 기본 셋팅했습니다.
프로젝트 최상위 layout 폴더에 AppProvider로 감싸서 전역에서 컨택스트를 사용할 수 있게 했습니다.
앞으로 작업하시면서 Context로 관리할 데이터가 생기면 _context 폴더안에 Context 파일을 파셔서 
AppContext에서 Provider 추가해주시면 됩니다.

3. AuthContext 작업했습니다.
로그인, 유저 정보와 토큰 관리하는 컨택스트입니다.
인스턴스 토큰 처리하는것때문에 먼저 작업했습니다.
간편한 접근성을 위해 useAuth 훅으로 따로 분리해두었습니다.

4. 토큰 디코딩을 위해 jwt-decode 새로운 패키지 설치했습니다.
추후 머지되면 최신화 하실때 npm i 한번씩 부탁드립니다.


### 작업 결과

![image](https://github.com/user-attachments/assets/a0c711da-7685-4a34-8b23-6fb7c404ba45)
