### PR TITLE
Feature/#70 내 프로필 등록 페이지 구현

### DIFF
--- a/src/app/_components/Dropdown.tsx
+++ b/src/app/_components/Dropdown.tsx
@@ -1,3 +1,4 @@
+'use client';
 import clsx from 'clsx';
 import Image from 'next/image';
 import { useEffect, useRef, useState } from 'react';

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,0 +1,5 @@
+const ProfilePage = () => {
+  return <>프로필 페이지</>;
+};
+
+export default ProfilePage;

--- a/src/app/profile/post/page.tsx
+++ b/src/app/profile/post/page.tsx
@@ -1,0 +1,38 @@
+import Footer from '@/app/_components/Footer';
+import Header from '@/app/_components/Header';
+import Image from 'next/image';
+import { Input } from '@/app/_components/Input';
+import Button from '@/app/_components/Button';
+import { Dropdown } from '@/app/_components/Dropdown';
+
+const ProfilePost = () => {
+  return (
+    <div>
+      <Header />
+      <form>
+        <div>
+          <h1>내 프로필</h1>
+          <button>
+            <Image
+              src={'/image/closeBtn.svg'}
+              alt='닫기버튼'
+              width={24}
+              height={24}
+            />
+          </button>
+        </div>
+        <div>
+          <Input label='이름*' />
+          <Input label='연락처*' />
+          <Dropdown options={[]} />
+        </div>
+
+        <Input label='소개' />
+        <Button>등록하기</Button>
+      </form>
+      <Footer />
+    </div>
+  );
+};
+
+export default ProfilePost;

--- a/src/app/profile/post/page.tsx
+++ b/src/app/profile/post/page.tsx
@@ -10,6 +10,7 @@ import LOCATIONS from '@/app/_constants/Location';
 import { useState } from 'react';
 import { Modal } from '@/app/_components/Modal';
 import { useRouter } from 'next/navigation';
+import axios from 'axios';
 
 interface FormData {
   name: string;
@@ -36,19 +37,29 @@ const ProfilePost = () => {
     });
   };
 
-  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    setIsModalOpen(true);
-    console.log('Form Submitted:', formData);
+    try {
+      const response = await axios.put(`/user/user_id`, {
+        item: {
+          name: formData.name,
+          phone: formData.contact,
+          address: formData.location,
+          bio: formData.introduction,
+        },
+      });
+      setIsModalOpen(true);
+    } catch (error) {
+      console.error('Error submitting form:', error);
+      alert('프로필 등록 중 문제가 발생했습니다. 다시 시도해주세요.');
+    }
   };
 
   const closeModal = () => {
-    console.log('Modal closed');
     setIsModalOpen(false);
   };
 
   const handleConfirm = () => {
-    console.log('Navigating to /profile'); // 디버깅 로그 추가
     setIsModalOpen(false);
     router.push('/profile');
   };
@@ -121,14 +132,13 @@ const ProfilePost = () => {
       </div>
       <Footer />
 
-      {/* 모달 */}
       {isModalOpen && (
         <Modal
           isOpen={isModalOpen}
           type='success'
           content={<p>프로필이 성공적으로 등록되었습니다!</p>}
           onClose={closeModal}
-          onConfirm={handleConfirm} // 확인 버튼에 핸들러 추가
+          onConfirm={handleConfirm}
         />
       )}
     </div>

--- a/src/app/profile/post/page.tsx
+++ b/src/app/profile/post/page.tsx
@@ -8,6 +8,8 @@ import Button from '@/app/_components/Button';
 import { Dropdown } from '@/app/_components/Dropdown';
 import LOCATIONS from '@/app/_constants/Location';
 import { useState } from 'react';
+import { Modal } from '@/app/_components/Modal';
+import { useRouter } from 'next/navigation';
 
 interface FormData {
   name: string;
@@ -17,12 +19,15 @@ interface FormData {
 }
 
 const ProfilePost = () => {
+  const router = useRouter();
   const [formData, setFormData] = useState<FormData>({
     name: '',
     contact: '',
-    location: '', // 초기값을 빈 문자열로 설정
+    location: '',
     introduction: '',
   });
+
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   const handleChange = (key: keyof FormData, value: string) => {
     setFormData({
@@ -33,7 +38,19 @@ const ProfilePost = () => {
 
   const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
+    setIsModalOpen(true);
     console.log('Form Submitted:', formData);
+  };
+
+  const closeModal = () => {
+    console.log('Modal closed');
+    setIsModalOpen(false);
+  };
+
+  const handleConfirm = () => {
+    console.log('Navigating to /profile'); // 디버깅 로그 추가
+    setIsModalOpen(false);
+    router.push('/profile');
   };
 
   return (
@@ -56,7 +73,7 @@ const ProfilePost = () => {
             </button>
           </div>
 
-          <div className='grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 mb-6 '>
+          <div className='grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 mb-6'>
             <Input
               label='이름*'
               placeholder='이름을 입력해주세요'
@@ -73,7 +90,7 @@ const ProfilePost = () => {
             />
             <Dropdown
               options={LOCATIONS}
-              value={formData.location || undefined} // 선택 전에는 빈 값 유지
+              value={formData.location || undefined}
               onChange={(value) => handleChange('location', value)}
               className='w-full h-[92px] mt-2'
             />
@@ -103,6 +120,17 @@ const ProfilePost = () => {
         </form>
       </div>
       <Footer />
+
+      {/* 모달 */}
+      {isModalOpen && (
+        <Modal
+          isOpen={isModalOpen}
+          type='success'
+          content={<p>프로필이 성공적으로 등록되었습니다!</p>}
+          onClose={closeModal}
+          onConfirm={handleConfirm} // 확인 버튼에 핸들러 추가
+        />
+      )}
     </div>
   );
 };

--- a/src/app/profile/post/page.tsx
+++ b/src/app/profile/post/page.tsx
@@ -1,35 +1,107 @@
+'use client';
+
 import Footer from '@/app/_components/Footer';
 import Header from '@/app/_components/Header';
 import Image from 'next/image';
 import { Input } from '@/app/_components/Input';
 import Button from '@/app/_components/Button';
 import { Dropdown } from '@/app/_components/Dropdown';
+import LOCATIONS from '@/app/_constants/Location';
+import { useState } from 'react';
+
+interface FormData {
+  name: string;
+  contact: string;
+  location: string;
+  introduction: string;
+}
 
 const ProfilePost = () => {
+  const [formData, setFormData] = useState<FormData>({
+    name: '',
+    contact: '',
+    location: '', // 초기값을 빈 문자열로 설정
+    introduction: '',
+  });
+
+  const handleChange = (key: keyof FormData, value: string) => {
+    setFormData({
+      ...formData,
+      [key]: value,
+    });
+  };
+
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    console.log('Form Submitted:', formData);
+  };
+
   return (
     <div>
       <Header />
-      <form>
-        <div>
-          <h1>내 프로필</h1>
-          <button>
-            <Image
-              src={'/image/closeBtn.svg'}
-              alt='닫기버튼'
-              width={24}
-              height={24}
-            />
-          </button>
-        </div>
-        <div>
-          <Input label='이름*' />
-          <Input label='연락처*' />
-          <Dropdown options={[]} />
-        </div>
+      <div className='max-w-full md:pt-[100px] h-[753px]'>
+        <form
+          className='max-w-screen-lg mx-auto p-6'
+          onSubmit={handleSubmit}
+          style={{ width: '100%', maxWidth: '964px' }}>
+          <div className='flex justify-between items-center mb-6'>
+            <h1 className='text-[20px] font-bold'>내 프로필</h1>
+            <button type='button'>
+              <Image
+                src={'/image/closeBtn.svg'}
+                alt='닫기버튼'
+                width={24}
+                height={24}
+              />
+            </button>
+          </div>
 
-        <Input label='소개' />
-        <Button>등록하기</Button>
-      </form>
+          <div className='grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 mb-6 '>
+            <Input
+              label='이름*'
+              placeholder='이름을 입력해주세요'
+              value={formData.name}
+              onChange={(e) => handleChange('name', e.target.value)}
+              className='w-full h-[92px] mt-2'
+            />
+            <Input
+              label='연락처*'
+              placeholder='연락처를 입력해주세요'
+              value={formData.contact}
+              onChange={(e) => handleChange('contact', e.target.value)}
+              className='w-full h-[92px] mt-2'
+            />
+            <Dropdown
+              options={LOCATIONS}
+              value={formData.location || undefined} // 선택 전에는 빈 값 유지
+              onChange={(value) => handleChange('location', value)}
+              className='w-full h-[92px] mt-2'
+            />
+          </div>
+
+          <div className='mb-6 mt-2'>
+            <div className='flex flex-col'>
+              <label
+                htmlFor='introduction'
+                className='mb-2 text-sm font-medium'>
+                소개
+              </label>
+              <textarea
+                id='introduction'
+                placeholder='자기소개를 입력해주세요'
+                value={formData.introduction}
+                onChange={(e) => handleChange('introduction', e.target.value)}
+                className='w-full h-[187px] border rounded p-2'></textarea>
+            </div>
+          </div>
+
+          <div className='text-center'>
+            <Button type='submit' size='xl'>
+              등록하기
+            </Button>
+          </div>
+        </form>
+      </div>
       <Footer />
     </div>
   );


### PR DESCRIPTION
### 이슈 번호

close #70 

### 작업 사항 요약

- 이름, 연락처, 주소는 필수 입력이고 소개는 선택입니다. 
  - 하지만 아직 구현은 하지 않았습니다. 아마 지윤님께서 업데이트 하신 usehook 사용하면 될 것 같습니다.
- 등록하기 버튼을 누르면 모달 창이 나옵니다.
- 모달 창에서 확인 버튼을 누르면 /profile 페이지로 이동합니다.
- api 등록도 해놨습니다. (테스트는 로그인 기능 구현 된 후에 하겠습니다.)
- dropdown에 label표시를 지윤님께서 추가해주셔서 PR올리고 새로 브랜치 만든 후 수정하겠습니다.
- 테블릿 사이즈에서 헤더에 폰트 깨지는 거는 이미 develop브랜치에 머지돼있어 신경 쓰지 않으셔도 됩니다.

### 작업 결과
![image](https://github.com/user-attachments/assets/24fbc295-ce7d-47ca-9953-2a17105bbf92)
![image](https://github.com/user-attachments/assets/e171a6f0-1a81-4eea-b9dd-47126a5d1608)
![image](https://github.com/user-attachments/assets/2b09fefb-c550-4998-bbe3-f3b693151cd4)


