### PR TITLE
Feat: 가게 공고 등록 페이지 구현

### DIFF
--- a/src/app/announce/post/page.tsx
+++ b/src/app/announce/post/page.tsx
@@ -140,7 +140,7 @@ const PostAnnounce = () => {
               content='등록이 완료되었습니다.'
               onClose={() => {
                 closeModal();
-                router.push('/announce/detail/123');
+                router.replace('/announce/detail/123');
               }}
             />
           </div>

--- a/src/app/announce/post/page.tsx
+++ b/src/app/announce/post/page.tsx
@@ -1,0 +1,154 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useModal } from '@/app/_hooks/useModal';
+import { useForm } from 'react-hook-form';
+import Button from '@/app/_components/Button';
+import Header from '@/app/_components/header';
+import { Input } from '@/app/_components/Input';
+import { Modal } from '@/app/_components/Modal';
+import clsx from 'clsx';
+import Footer from '@/app/_components/footer';
+
+const PostAnnounce = () => {
+  const router = useRouter();
+  const { isOpen, openModal, closeModal } = useModal();
+  const now = new Date();
+  const localDateTime = new Date(
+    now.getTime() - now.getTimezoneOffset() * 60000,
+  )
+    .toISOString()
+    .slice(0, 16);
+  const {
+    register,
+    handleSubmit,
+
+    formState: { errors },
+  } = useForm({
+    mode: 'all',
+    defaultValues: {
+      hourlyPay: '',
+      startsAt: localDateTime,
+      workhour: '',
+      description: '',
+    },
+  });
+
+  const onSubmit = (data: Record<string, any>) => {
+    const localDate = new Date(data.startsAt);
+    const utcDate = localDate.toISOString();
+
+    const payload = {
+      ...data,
+      startsAt: utcDate,
+    };
+
+    console.log('Payload to submit:', payload);
+
+    openModal();
+  };
+
+  return (
+    <>
+      <Header />
+      <div className='bg-gray-50'>
+        <div className='w-full bg-gray-50'>
+          <div
+            className={clsx(
+              'mx-auto pt-10 pb-[80px] md:py-28 lg:py-36',
+              'px-4 md:px-0',
+              'max-w-[90%] sm:max-w-[680px] lg:max-w-[964px]',
+              'pb-[80px] md:pb-[60px]',
+            )}>
+            <div className='flex justify-between mb-6'>
+              <div className='text-20b'>공고 등록</div>
+              <p
+                className='cursor-pointer text-18m hover:text-red-40'
+                onClick={() => window.history.back()}>
+                ✖
+              </p>
+            </div>
+
+            <div
+              className={clsx(
+                'relative z-10 grid gap-5 gap-y-7',
+                'grid-cols-1 md:grid-cols-2',
+                'lg:grid-cols-[1fr_1fr_1fr]',
+              )}>
+              <Input
+                label='시급*'
+                rightAddon='원'
+                className='relative'
+                error={errors.hourlyPay?.message}
+                {...register('hourlyPay', {
+                  required: '기본 시급을 입력해 주세요.',
+                  validate: (value) =>
+                    parseInt(value, 10) >= 10030 ||
+                    '시급은 10,030원 이상만 입력할 수 있어요.',
+                  pattern: {
+                    value: /^\d+$/,
+                    message: '시급은 숫자만 입력할 수 있어요.',
+                  },
+                })}
+              />
+              <Input
+                label='시작 일시*'
+                type='datetime-local'
+                error={errors.startsAt?.message}
+                {...register('startsAt', {
+                  required: '시작 일시를 입력해 주세요.',
+                })}
+              />
+              <Input
+                label='업무 시간*'
+                rightAddon='시간'
+                className='relative'
+                error={errors.workhour?.message}
+                {...register('workhour', {
+                  required: '업무 시간을 입력해 주세요.',
+                  pattern: {
+                    value: /^\d+$/,
+                    message: '업무 시간은 숫자만 입력할 수 있어요.',
+                  },
+                })}
+              />
+              <div className='col-span-1 md:col-span-2 flex flex-col gap-2 w-full lg:col-[span_3]'>
+                <div>공고 설명</div>
+                <textarea
+                  className={clsx(
+                    'h-[153px] w-full border rounded-md pt-4 pl-5 resize-none',
+                    'focus:border-black focus:outline-none',
+                  )}
+                  placeholder='입력'
+                  {...register('description')}
+                />
+              </div>
+              <div className='col-span-1 md:col-span-2 lg:col-span-3 flex justify-center lg:justify-center'>
+                <Button
+                  size='md'
+                  type='button'
+                  onClick={handleSubmit(onSubmit)}
+                  className='mt-4'>
+                  등록하기
+                </Button>
+              </div>
+            </div>
+
+            <Modal
+              isOpen={isOpen}
+              type='success'
+              content='등록이 완료되었습니다.'
+              onClose={() => {
+                closeModal();
+                router.push('/announce/detail/123');
+              }}
+            />
+          </div>
+        </div>
+      </div>
+      <Footer />
+    </>
+  );
+};
+
+export default PostAnnounce;

--- a/src/app/store/edit/page.tsx
+++ b/src/app/store/edit/page.tsx
@@ -14,7 +14,7 @@ import ImageUploader from '@/app/_components/ImageUploader';
 import { useModal } from '@/app/_hooks/useModal';
 import { CATEGORIES, LOCATIONS } from '@/app/_constants/constants';
 
-const PostStore = () => {
+const EditStore = () => {
   const router = useRouter();
   const { isOpen, openModal, closeModal } = useModal();
   const {
@@ -185,4 +185,4 @@ const PostStore = () => {
   );
 };
 
-export default PostStore;
+export default EditStore;

--- a/src/app/store/edit/page.tsx
+++ b/src/app/store/edit/page.tsx
@@ -174,7 +174,7 @@ const EditStore = () => {
               content='수정이 완료되었습니다.'
               onClose={() => {
                 closeModal();
-                router.push('/store/detail/123');
+                router.replace('/store/detail/123');
               }}
             />
           </div>

--- a/src/app/store/post/page.tsx
+++ b/src/app/store/post/page.tsx
@@ -13,7 +13,6 @@ import { Modal } from '@/app/_components/Modal';
 import ImageUploader from '@/app/_components/ImageUploader';
 import { useModal } from '@/app/_hooks/useModal';
 import { CATEGORIES, LOCATIONS } from '@/app/_constants/constants';
-import Image from 'next/image';
 
 const PostStore = () => {
   const router = useRouter();
@@ -72,14 +71,11 @@ const PostStore = () => {
             )}>
             <div className='flex justify-between mb-6'>
               <div className='text-20b'>가게 정보</div>
-              <Image
-                src='/image/cancel-icon.svg'
-                alt='닫기'
-                width={18}
-                height={18}
-                className='cursor-pointer'
-                onClick={() => console.log('폼 닫기')}
-              />
+              <p
+                className='cursor-pointer text-18m hover:text-red-40'
+                onClick={() => window.history.back()}>
+                ✖
+              </p>
             </div>
 
             <div className='relative z-10 grid grid-cols-1 md:grid-cols-2 gap-5 md:gap-y-5'>

--- a/src/app/store/post/page.tsx
+++ b/src/app/store/post/page.tsx
@@ -174,7 +174,7 @@ const PostStore = () => {
               content='등록이 완료되었습니다.'
               onClose={() => {
                 closeModal();
-                router.push('/store/detail/123');
+                router.replace('/store/detail/123');
               }}
             />
           </div>


### PR DESCRIPTION
### 이슈 번호

close #80 

### 작업 사항 요약
- 가게 공고 등록 페이지 구현(API 미구현)
- 가게 정보 수정 컴포넌트명 수정/가게 정보 등록 스타일 수정
- 가게 공고 등록 페이지의 경우 Footer 부분이 없는데 조금 허전해서 넣었고, Footer 아래부분 하얀 배경이 보이는 게 조금 어색해서 메인 부분 상하 부분에 패딩 넣었습니다.
- 시급의 경우 2025년 기준 최저시급 이상(10,030원) 이상만 올 수 있도록 유효성 검사 추가했습니다.

### 작업 결과
![가게 공고 등록 - 모바일](https://github.com/user-attachments/assets/11d9760e-f767-4f87-90f4-8fdd803a63bd)
![가게 공고 등록 - 태블릿](https://github.com/user-attachments/assets/aac1f0ed-4419-4f0d-8c15-9ef6fc6f077f)
![가게 공고 등록 - 데스크탑](https://github.com/user-attachments/assets/9738997a-5285-4223-8547-eaa4c488c90c)
