### PR TITLE
Feature/#91 가게정보등록api구현및리팩토링

### DIFF
--- a/src/app/_components/Dropdown.tsx
+++ b/src/app/_components/Dropdown.tsx
@@ -14,7 +14,7 @@ interface DropdownProps<T = string> {
   error?: string;
 }
 
-export const Dropdown = <T,>({
+const Dropdown = <T,>({
   options,
   value,
   label,
@@ -113,3 +113,5 @@ export const Dropdown = <T,>({
     </div>
   );
 };
+
+export default Dropdown;

--- a/src/app/_components/Input.tsx
+++ b/src/app/_components/Input.tsx
@@ -8,7 +8,7 @@ interface InputProps extends React.InputHTMLAttributes<HTMLInputElement> {
   error?: string;
 }
 
-export const Input = ({
+const Input = ({
   className,
   inputClassName,
   label,
@@ -42,3 +42,5 @@ export const Input = ({
     </div>
   );
 };
+
+export default Input;

--- a/src/app/_components/Modal.tsx
+++ b/src/app/_components/Modal.tsx
@@ -13,7 +13,7 @@ interface ModalProps {
   questionType?: 'cancel' | 'approve' | 'reject';
 }
 
-export const Modal = ({
+const Modal = ({
   isOpen,
   type,
   content,
@@ -94,3 +94,5 @@ export const Modal = ({
     </div>
   );
 };
+
+export default Modal;

--- a/src/app/_hooks/useModal.ts
+++ b/src/app/_hooks/useModal.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 
-export const useModal = () => {
+const useModal = () => {
   const [isOpen, setIsOpen] = useState(false);
 
   const openModal = () => setIsOpen(true);
@@ -8,3 +8,5 @@ export const useModal = () => {
 
   return { isOpen, openModal, closeModal };
 };
+
+export default useModal;

--- a/src/app/store/post/page.tsx
+++ b/src/app/store/post/page.tsx
@@ -1,20 +1,21 @@
 'use client';
 
+import { useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { Controller, useForm } from 'react-hook-form';
 import clsx from 'clsx';
 
-import Footer from '@/app/_components/Footer';
 import Header from '@/app/_components/Header';
+import Footer from '@/app/_components/Footer';
 import Button from '@/app/_components/Button';
-import { Input } from '@/app/_components/Input';
-import { Dropdown } from '@/app/_components/Dropdown';
-import { Modal } from '@/app/_components/Modal';
+import Input from '@/app/_components/Input';
+import Dropdown from '@/app/_components/Dropdown';
+import Modal from '@/app/_components/Modal';
 import ImageUploader from '@/app/_components/ImageUploader';
-import { useModal } from '@/app/_hooks/useModal';
+
+import useModal from '@/app/_hooks/useModal';
 import { CATEGORIES, LOCATIONS } from '@/app/_constants/constants';
 import { registerShop } from '@/app/_api/owner_api';
-import { useState } from 'react';
 
 const PostStore = () => {
   const router = useRouter();

--- a/src/app/store/post/page.tsx
+++ b/src/app/store/post/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useRouter } from 'next/navigation';
-import { useForm } from 'react-hook-form';
+import { Controller, useForm } from 'react-hook-form';
 import clsx from 'clsx';
 
 import Footer from '@/app/_components/Footer';
@@ -13,28 +13,22 @@ import { Modal } from '@/app/_components/Modal';
 import ImageUploader from '@/app/_components/ImageUploader';
 import { useModal } from '@/app/_hooks/useModal';
 import { CATEGORIES, LOCATIONS } from '@/app/_constants/constants';
+import { registerShop } from '@/app/_api/owner_api';
+import { useState } from 'react';
 
 const PostStore = () => {
   const router = useRouter();
   const { isOpen, openModal, closeModal } = useModal();
+  const [shopId, setShopId] = useState<string | null>(null);
   const {
+    control,
     register,
     handleSubmit,
     setValue,
     watch,
-    trigger,
     formState: { errors },
-  } = useForm({
+  } = useForm<ShopRequest>({
     mode: 'all',
-    defaultValues: {
-      name: '',
-      category: '',
-      address1: '',
-      address2: '',
-      originalHourlyPay: '',
-      description: '',
-      imageUrl: '',
-    },
   });
 
   const imageUrl: string = watch('imageUrl');
@@ -46,138 +40,150 @@ const PostStore = () => {
     setValue('imageUrl', '');
   };
 
-  const onSubmit = (data: Record<string, any>) => {
-    openModal();
+  const onSubmit = async (data: ShopRequest) => {
+    try {
+      const response = await registerShop(data);
+      setShopId(response.data.item.id);
+      openModal();
+    } catch (err) {
+      console.log('가게를 등록하는데 에러가 발생했어요:', err);
+    }
   };
-
-  register('category', {
-    required: '분류를 선택해 주세요.',
-  });
-
-  register('address1', {
-    required: '주소를 선택해 주세요.',
-  });
 
   return (
     <>
       <Header />
       <div className='bg-gray-50'>
-        <div>
+        <div
+          className={clsx(
+            'mx-auto pt-10 px-4 sm:px-6 lg:px-8',
+            'w-full max-w-[90%] sm:max-w-[680px] lg:max-w-[964px]',
+            'pb-[80px] md:pb-[60px]',
+          )}>
+          <div className='flex justify-between mb-8'>
+            <div className='text-20b'>가게 정보</div>
+            <p
+              className='cursor-pointer text-18m hover:text-red-40'
+              onClick={() =>
+                window.confirm(
+                  '가게 정보 등록을 취소하시겠습니까?\n\n작성된 데이터가 사라질 수 있습니다.',
+                ) && router.back()
+              }>
+              ✖
+            </p>
+          </div>
+
           <div
             className={clsx(
-              'mx-auto pt-10 px-4 sm:px-6 lg:px-8',
-              'w-full max-w-[90%] sm:max-w-[680px] lg:max-w-[964px]',
-              'pb-[80px] md:pb-[60px]',
+              'relative z-10 grid gap-5 md:gap-y-5',
+              'grid-cols-1 md:grid-cols-2',
             )}>
-            <div className='flex justify-between mb-6'>
-              <div className='text-20b'>가게 정보</div>
-              <p
-                className='cursor-pointer text-18m hover:text-red-40'
-                onClick={() => window.history.back()}>
-                ✖
-              </p>
-            </div>
-
-            <div className='relative z-10 grid grid-cols-1 md:grid-cols-2 gap-5 md:gap-y-5'>
-              <Input
-                label='가게 이름*'
-                placeholder='입력'
-                error={errors.name?.message}
-                {...register('name', {
-                  required: '가게 이름을 입력해 주세요.',
-                })}
-              />
-              <div className='relative'>
-                <Dropdown
-                  label='분류*'
-                  options={CATEGORIES}
-                  placeholder='선택'
-                  value={watch('category')}
-                  onChange={(value) => {
-                    setValue('category', value);
-                    trigger('category');
-                  }}
-                  onBlur={() => trigger('category')}
-                  error={errors.category?.message}
-                  className='relative'
-                />
-              </div>
-              <div className='relative'>
-                <Dropdown
-                  label='주소*'
-                  options={LOCATIONS}
-                  placeholder='선택'
-                  value={watch('address1')}
-                  onChange={(value) => {
-                    setValue('address1', value);
-                    trigger('address1');
-                  }}
-                  onBlur={() => trigger('address1')}
-                  error={errors.address1?.message}
-                  className='relative'
-                />
-              </div>
-              <Input
-                label='상세 주소*'
-                placeholder='입력'
-                error={errors.address2?.message}
-                {...register('address2', {
-                  required: '상세 주소를 입력해 주세요.',
-                })}
-              />
-              <Input
-                label='기본 시급*'
-                placeholder='입력'
-                rightAddon='원'
-                className='relative'
-                error={errors.originalHourlyPay?.message}
-                {...register('originalHourlyPay', {
-                  required: '기본 시급을 입력해 주세요.',
-                  pattern: {
-                    value: /^\d+$/,
-                    message: '시급은 숫자만 입력할 수 있어요.',
-                  },
-                })}
-              />
-              <ImageUploader
-                image={imageUrl}
-                label='가게 이미지'
-                onImageChange={onImageChange}
-                onImageDelete={onImageDelete}
-                mode='add'
-              />
-              <div className='col-span-1 md:col-span-2 flex flex-col gap-2'>
-                <div>가게 설명</div>
-                <textarea
-                  className={clsx(
-                    'h-[153px] w-full border rounded-md pt-4 pl-5 resize-none',
-                    'focus:border-black focus:outline-none',
-                  )}
-                  placeholder='입력'
-                  {...register('description')}
-                />
-              </div>
-              <div className='col-span-1 md:col-span-2 flex justify-center'>
-                <Button
-                  size='md'
-                  type='button'
-                  onClick={handleSubmit(onSubmit)}
-                  className='mt-4'>
-                  등록하기
-                </Button>
-              </div>
-            </div>
-
-            <Modal
-              isOpen={isOpen}
-              type='success'
-              content='등록이 완료되었습니다.'
-              onClose={() => {
-                closeModal();
-                router.replace('/store/detail/123');
-              }}
+            <Input
+              label='가게 이름*'
+              error={errors.name?.message}
+              {...register('name', {
+                required: '가게 이름을 입력해 주세요.',
+              })}
             />
+
+            <div className='relative'>
+              <Controller
+                name='category'
+                control={control}
+                rules={{ required: '분류를 선택해 주세요.' }}
+                render={({ field }) => (
+                  <Dropdown
+                    {...field}
+                    label='분류*'
+                    options={CATEGORIES}
+                    error={errors.category?.message}
+                    className='relative'
+                  />
+                )}
+              />
+            </div>
+
+            <div className='relative'>
+              <Controller
+                name='address1'
+                control={control}
+                rules={{ required: '주소를 선택해 주세요.' }}
+                render={({ field }) => (
+                  <Dropdown
+                    {...field}
+                    label='주소*'
+                    options={LOCATIONS}
+                    error={errors.address1?.message}
+                    className='relative'
+                  />
+                )}
+              />
+            </div>
+
+            <Input
+              label='상세 주소*'
+              error={errors.address2?.message}
+              {...register('address2', {
+                required: '상세 주소를 입력해 주세요.',
+              })}
+            />
+
+            <Input
+              label='기본 시급*'
+              rightAddon='원'
+              className='relative'
+              error={errors.originalHourlyPay?.message}
+              {...register('originalHourlyPay', {
+                required: '기본 시급을 입력해 주세요.',
+                pattern: {
+                  value: /^\d+$/,
+                  message: '시급은 숫자만 입력할 수 있어요.',
+                },
+              })}
+            />
+
+            <ImageUploader
+              image={imageUrl}
+              label='가게 이미지'
+              onImageChange={onImageChange}
+              onImageDelete={onImageDelete}
+              mode='add'
+            />
+
+            <div className='col-span-1 md:col-span-2 flex flex-col gap-2'>
+              <div>가게 설명</div>
+              <textarea
+                className={clsx(
+                  'h-[153px] w-full border rounded-md pt-4 pl-5 resize-none',
+                  'focus:border-black focus:outline-none',
+                )}
+                placeholder='입력'
+                {...register('description')}
+              />
+            </div>
+
+            <div className='col-span-1 md:col-span-2 flex justify-center'>
+              <Button
+                size='md'
+                type='button'
+                onClick={handleSubmit(onSubmit)}
+                className='mt-4'>
+                등록하기
+              </Button>
+            </div>
           </div>
+
+          <Modal
+            isOpen={isOpen}
+            type='success'
+            content='등록이 완료되었습니다.'
+            onClose={() => {
+              closeModal();
+              if (shopId) {
+                router.replace(`/store/detail/${shopId}`);
+              }
+            }}
+          />
         </div>
       </div>
       <Footer />


### PR DESCRIPTION
### 이슈 번호

close #91 

### 작업 사항 요약
- **API**: `registerShop` 함수를 통하여 Post 요청을 보내고 등록된 가게의 id(`response.data.item.id`)를 setShopId을 통해 변경 후 모달을 닫으면 router.replace(`/store/detail/${shopId}`);를 통해 상세 페이지로 리다이렉션 하도록 하였습니다.
- **Refactor 1**: 하림님께서 말씀하셨던 `Controller`를  Dropdown에 사용하여, 코드를 간결화 하였습니다. 
- **Refactor 2**: 오른쪽 상단 X 버튼 클릭 시 아래 사진과 같이 경고(window confirm) 창이 열리고, 확인 클릭 시 `뒤로가기` 취소 클릭시 해당 창이 닫히도록 하였습니다.
- **Refactor 3**: useHookForm에 어떤 구조가 들어올지 예상하기 쉽게 각 input에 `defaultValue`를 지정하였는데, 코드가 길어지고 필수 요소는 아니라 삭제하였습니다.
- **Refactor 4**: `export -> export default` 변경하여 import문에서의 중괄호를 없애는 작업
- **Refactor 5**: 폼 내부 박스 간 한 행씩 띄어 `가독성 개선`하였습니다. 
- **Refactor 6**: 스타일 세부 수정 및 불필요한 placeholder 삭제하였습니다.
- **추가 할 내용이나 개선할 점 있으면 바로 수정하도록 하겠습니다.**

### 작업 결과
- API 자체는 401 에러가 뜨는 거 보니 아마 회원가입/로그인 구현 이후 테스트 해보면 잘 작동할 것 같습니다. 
- 이 외 이미지나 폼 유효성 검사 등은 정상 작동합니다.

![image](https://github.com/user-attachments/assets/3070e69e-b133-4723-aa46-9fdb3a86711a)

