### PR TITLE
Feature/#115 프로필페이지에유저데이터연결

### DIFF
--- a/src/app/_components/PostProfile.tsx
+++ b/src/app/_components/PostProfile.tsx
@@ -5,40 +5,36 @@ import Button from '@/app/_components/Button';
 interface PostProps {
   isExist: boolean;
   type: keyof typeof POST_TYPE_CONFIG;
+  navigateTo: string;
 }
 
 const POST_TYPE_CONFIG = {
   myStore: {
     title: '내 가게',
-    navigateTo: '',
     buttonLabel: '가게 등록하기',
     description: '내 가게를 소개하고 공고도 등록해 보세요.',
   },
   announcement: {
     title: '등록된 공고',
-    navigateTo: '',
     buttonLabel: '공고 등록하기',
     description: '공고를 등록해 보세요.',
   },
   profile: {
     title: '내 프로필',
-    navigateTo: '',
     buttonLabel: '내 프로필 등록하기',
     description: '내 프로필을 등록하고 원하는 가게에 지원해 보세요.',
   },
   application: {
     title: '신청 내역',
-    navigateTo: '',
     buttonLabel: '공고 보러가기',
     description: '아직 신청 내역이 없어요.',
   },
 } as const;
 
-const PostProfile = ({ isExist, type }: PostProps) => {
+const PostProfile = ({ isExist, type, navigateTo }: PostProps) => {
   if (isExist) return null;
 
-  const { title, navigateTo, buttonLabel, description } =
-    POST_TYPE_CONFIG[type];
+  const { title, buttonLabel, description } = POST_TYPE_CONFIG[type];
 
   return (
     <div className='flex justify-center items-center'>

--- a/src/app/_components/header.tsx
+++ b/src/app/_components/header.tsx
@@ -6,17 +6,32 @@ import Logo from './Logo';
 import NotificationModal from './NotificationModal/NotificationModal';
 
 import { useState } from 'react';
+import { jwtDecode } from 'jwt-decode'; // 토큰 디코드 라이브러리
 import { useAuth } from '../_hooks/useAuth';
 import { useWindowWidth } from '../_hooks/useWindowWidth';
 import { useNotifications } from '../_hooks/useNotifications';
 
 const Header = () => {
-  const { user, logout } = useAuth();
+  const { user, token, logout } = useAuth();
   const windowWidth = useWindowWidth();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
   // 알림 상태 가져오기
   const isNotificationActive = useNotifications();
+
+  // 토큰에서 유저 타입 가져오기
+  const getUserType = () => {
+    if (!token) return null;
+    try {
+      const decoded = jwtDecode<{ type: string }>(token); // 토큰 디코드
+      return decoded.type;
+    } catch (error) {
+      console.error('토큰 decode에 실패하였습니다:', error);
+      return null;
+    }
+  };
+
+  const userType = getUserType();
 
   // 알림 모달 토글
   const toggleModal = () => {
@@ -49,7 +64,8 @@ const Header = () => {
     <div className='relative'>
       {user ? (
         <div className='flex gap-4 lg:gap-10'>
-          <Link href={'/store'}>내 가게</Link>
+          {userType === 'employer' && <Link href={'/store'}>내 가게</Link>}
+          {userType === 'employee' && <Link href={'/profile'}>내 프로필</Link>}
           <button onClick={logout}>로그아웃</button>
           <button onClick={toggleModal}>
             {isNotificationActive ? (

--- a/src/app/_config/tableConfig.tsx
+++ b/src/app/_config/tableConfig.tsx
@@ -8,7 +8,7 @@ interface OwnerData {
   status: string;
 }
 
-interface WorkerData {
+export interface WorkerData {
   shopName: string;
   date: string;
   hourlyPay: string;

--- a/src/app/profile/_components/ProfileCard.tsx
+++ b/src/app/profile/_components/ProfileCard.tsx
@@ -2,6 +2,7 @@
 import Button from '@/app/_components/Button';
 import Image from 'next/image';
 import Link from 'next/link';
+import { useParams } from 'next/navigation';
 
 interface ProfileData {
   name?: string;
@@ -11,6 +12,8 @@ interface ProfileData {
 }
 
 const ProfileCard = (profiledata: ProfileData) => {
+  const { id } = useParams();
+  const user_id = id as string;
   return (
     <div className='flex justify-center px-4 py-6'>
       <div
@@ -39,7 +42,7 @@ const ProfileCard = (profiledata: ProfileData) => {
                 {profiledata.name}
               </div>
             </div>
-            <Link href={'/profile/post'}>
+            <Link href={`/profile/post/${user_id}`}>
               <Button style='bordered' size='sm' className='ml-4'>
                 편집하기
               </Button>

--- a/src/app/profile/_components/ProfileCard.tsx
+++ b/src/app/profile/_components/ProfileCard.tsx
@@ -2,8 +2,11 @@
 import Button from '@/app/_components/Button';
 import Image from 'next/image';
 import Link from 'next/link';
-import { useParams } from 'next/navigation';
 
+interface ProfileCardProps {
+  profiledata: ProfileData;
+  user_id: string;
+}
 interface ProfileData {
   name?: string;
   contact?: string;
@@ -11,9 +14,7 @@ interface ProfileData {
   introduction?: string;
 }
 
-const ProfileCard = (profiledata: ProfileData) => {
-  const { id } = useParams();
-  const user_id = id as string;
+const ProfileCard = (props: ProfileCardProps) => {
   return (
     <div className='flex justify-center px-4 py-6'>
       <div
@@ -39,10 +40,10 @@ const ProfileCard = (profiledata: ProfileData) => {
             <div>
               <div className='text-red-500 text-sm font-medium mb-1'>이름</div>
               <div className='text-black text-xl font-bold'>
-                {profiledata.name}
+                {props.profiledata.name}
               </div>
             </div>
-            <Link href={`/profile/post/${user_id}`}>
+            <Link href={`/profile/post/${props.user_id}`}>
               <Button style='bordered' size='sm' className='ml-4'>
                 편집하기
               </Button>
@@ -56,7 +57,9 @@ const ProfileCard = (profiledata: ProfileData) => {
                 width={20}
                 height={20}
               />
-              <span className='text-black text-sm'>{profiledata.contact}</span>
+              <span className='text-black text-sm'>
+                {props.profiledata.contact}
+              </span>
             </div>
             <div className='flex items-center gap-2'>
               <Image
@@ -66,11 +69,13 @@ const ProfileCard = (profiledata: ProfileData) => {
                 height={20}
               />
               <span className='text-black text-sm'>
-                선호 지역: {profiledata.location}
+                선호 지역: {props.profiledata.location}
               </span>
             </div>
           </div>
-          <div className='text-black text-sm'>{profiledata.introduction}</div>
+          <div className='text-black text-sm'>
+            {props.profiledata.introduction}
+          </div>
         </div>
       </div>
     </div>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -8,14 +8,10 @@ import ProfileCard from './_components/ProfileCard';
 import Table from '../_components/Table';
 import Pagination from '../_components/Pagination';
 import { getUserInfo, getUserApplications } from '../_api/worker_api';
-import { tableConfig } from '../_config/tableConfig';
-import { ProfileData, WorkerData } from './_type/type';
-import { useParams, useRouter } from 'next/navigation';
+import { tableConfig, WorkerData } from '../_config/tableConfig';
+import { ProfileData } from './_type/type';
 
 const ProfilePage = () => {
-  const router = useRouter();
-  const { id } = useParams();
-  const user_id = id as string;
   //상태 관리
   const [profileStatus, setProfileStatus] = useState(false);
   const [applicationStatus, setApplicationStatus] = useState(false);

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -9,9 +9,13 @@ import Table from '../_components/Table';
 import Pagination from '../_components/Pagination';
 import { getUserInfo, getUserApplications } from '../_api/worker_api';
 import { tableConfig } from '../_config/tableConfig';
-import { ProfileData, Application } from './_type/type';
+import { ProfileData, WorkerData } from './_type/type';
+import { useParams, useRouter } from 'next/navigation';
 
 const ProfilePage = () => {
+  const router = useRouter();
+  const { id } = useParams();
+  const user_id = id as string;
   //상태 관리
   const [profileStatus, setProfileStatus] = useState(false);
   const [applicationStatus, setApplicationStatus] = useState(false);
@@ -19,7 +23,7 @@ const ProfilePage = () => {
   const [error, setError] = useState<string | null>(null);
   // 데이터 관리
   const [profileData, setProfileData] = useState<ProfileData | null>(null);
-  const [applications, setApplications] = useState<Application[]>([]);
+  const [applications, setApplications] = useState<WorkerData[]>([]);
   // 페이지 네이션
   const [currentPage, setCurrentPage] = useState(1);
   const [itemsPerPage] = useState(5); // 한 페이지에 표시할 항목 수

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -120,10 +120,13 @@ const ProfilePage = () => {
           <div>
             {profileData && (
               <ProfileCard
-                name={profileData.name}
-                contact={profileData.phone || 'N/A'}
-                location={profileData.address || 'N/A'}
-                introduction={profileData.bio || 'N/A'}
+                profiledata={{
+                  name: profileData.name,
+                  contact: profileData.phone || 'N/A',
+                  location: profileData.address || 'N/A',
+                  introduction: profileData.bio || 'N/A',
+                }}
+                user_id={user_id}
               />
             )}
             {applicationStatus ? (

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -141,12 +141,20 @@ const ProfilePage = () => {
                 />
               </div>
             ) : (
-              <PostProfile isExist={applicationStatus} type='application' />
+              <PostProfile
+                isExist={applicationStatus}
+                type='application'
+                navigateTo={''}
+              />
             )}
           </div>
         ) : (
           <div>
-            <PostProfile isExist={profileStatus} type='profile' />
+            <PostProfile
+              isExist={profileStatus}
+              type='profile'
+              navigateTo={`/profile/post/${user_id}`}
+            />
             <div className='h-[358px]'></div>
           </div>
         )}

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -147,7 +147,7 @@ const ProfilePage = () => {
               <PostProfile
                 isExist={applicationStatus}
                 type='application'
-                navigateTo={''}
+                navigateTo={'/announce'}
               />
             )}
           </div>

--- a/src/app/profile/post/[id]/page.tsx
+++ b/src/app/profile/post/[id]/page.tsx
@@ -1,17 +1,18 @@
 'use client';
 
+import { useParams, useRouter } from 'next/navigation';
+import { useForm, Controller } from 'react-hook-form';
+import { useState } from 'react';
+import axios from 'axios';
+import Image from 'next/image';
+
 import Footer from '@/app/_components/Footer';
 import Header from '@/app/_components/Header';
-import Image from 'next/image';
-import { Input } from '@/app/_components/Input';
+import Input from '@/app/_components/Input';
 import Button from '@/app/_components/Button';
-import { Dropdown } from '@/app/_components/Dropdown';
+import Dropdown from '@/app/_components/Dropdown';
+import Modal from '@/app/_components/Modal';
 import { LOCATIONS } from '@/app/_constants/constants';
-import { Modal } from '@/app/_components/Modal';
-import { useRouter } from 'next/navigation';
-import { useForm, Controller } from 'react-hook-form';
-import axios from 'axios';
-import { useState } from 'react';
 
 interface FormData {
   name: string;
@@ -22,6 +23,8 @@ interface FormData {
 
 const ProfilePost = () => {
   const router = useRouter();
+  const { id } = useParams();
+  const user_id = id as string;
   const {
     control,
     handleSubmit,
@@ -41,7 +44,7 @@ const ProfilePost = () => {
   const onSubmit = async (data: FormData) => {
     console.log('폼 데이터:', data); // 폼 데이터 확인
     try {
-      const response = await axios.put(`/user/user_id`, {
+      const response = await axios.put(`/user/${user_id}`, {
         item: {
           name: data.name,
           phone: data.contact,


### PR DESCRIPTION
### 이슈 번호

close #115 

### 작업 사항 요약

- header 페이지에 token을 불러와 유저 타입을 확인하고, 유저 타입에 따라 상단 메뉴에 "내 프로필" 또는 "내 가게" 가 표시됩니다.
- 프로필 등록 페이지의 루트를 /profile/post 에서 /profile/post/[id] 페이지로 변경하였습니다.
- 프로필 페이지에서 토큰을 받아와 유저id를 가져왔습니다.
- PostProfile 컴포넌트의 prop에 페이지 이동 경로를 추가하였습니다.
- ProfileCard 컴포넌트의 prop에 user_id를 추가하여 프로필 수정(등록) 페이지로 이동할 수 있도록 하였습니다.
- 프로필 등록 페이지에서는 파라미터로 user_id를 들고오도록 하였습니다.
