### PR TITLE
Feature/#127 메인공고관련페이지작업

### DIFF
--- a/src/app/_components/Badge.tsx
+++ b/src/app/_components/Badge.tsx
@@ -28,7 +28,9 @@ export default function Badge({ status, percent, isPast }: BadgeProps) {
           ? '승인 완료'
           : status === '거절'
             ? '거절'
-            : '대기중'}
+            : status === '대기'
+              ? '대기중'
+              : ''}
       {percent !== undefined && (
         <Image
           src='/image/arrow-up-bold.svg'

--- a/src/app/_components/Button.tsx
+++ b/src/app/_components/Button.tsx
@@ -26,7 +26,7 @@ const Button: React.FC<ButtonProps> = ({
     'inline-flex items-center justify-center rounded-md',
     {
       'bg-primary text-white': style === 'default' && !disabled,
-      'border border-primary text-primary ':
+      'border bg-white border-primary text-primary ':
         style === 'bordered' && !disabled && !approval,
       'border border-blue-20 text-blue-20 ':
         style === 'bordered' && !disabled && approval,

--- a/src/app/_components/DetailFilter.tsx
+++ b/src/app/_components/DetailFilter.tsx
@@ -6,11 +6,22 @@ import Image from 'next/image';
 import { LOCATIONS } from '../_constants/constants';
 import Button from './Button';
 interface DetailFilterProps {
-  isVisible: boolean; // 폼 표시 제어
-  onClose?: () => void; // 상세 검색 폼 닫기 함수
+  isVisible: boolean;
+  onClose?: () => void;
+  className?: string;
+  onApply?: (filters: {
+    selectedOptions: string[];
+    amount: string;
+    startDate: string;
+  }) => void;
 }
 
-const DetailFilter: React.FC<DetailFilterProps> = ({ isVisible, onClose }) => {
+const DetailFilter: React.FC<DetailFilterProps> = ({
+  isVisible,
+  onClose,
+  onApply,
+  className,
+}) => {
   const [selectedOptions, setSelectedOptions] = useState<string[]>([]);
   const [amount, setAmount] = useState<string>('');
   const [startDate, setStartDate] = useState<string>('');
@@ -27,13 +38,38 @@ const DetailFilter: React.FC<DetailFilterProps> = ({ isVisible, onClose }) => {
     setSelectedOptions(selectedOptions.filter((item) => item !== option));
   };
 
+  const handleClose = () => {
+    setSelectedOptions([]);
+    setAmount('');
+    setStartDate('');
+    onClose?.();
+  };
+
+  const handleReset = () => {
+    setSelectedOptions([]);
+    setAmount('');
+    setStartDate('');
+
+    onApply?.({
+      selectedOptions: [],
+      amount: '',
+      startDate: '',
+    });
+  };
+
+  const handleApply = () => {
+    onApply?.({ selectedOptions, amount, startDate });
+    onClose?.();
+  };
+
   if (!isVisible) return null;
 
   return (
-    <form className='p-4 max-w-[375px] max-h-[840px] mx-auto bg-white rounded-[10px] shadow-md'>
+    <form
+      className={`p-4 max-w-[375px] max-h-[840px] mx-auto bg-white rounded-[10px] shadow-md ${className}`}>
       <div className='flex justify-between items-center mb-4'>
         <h2 className='text-xl font-bold'>상세 필터</h2>
-        <button type='button' className='text-gray-500' onClick={onClose}>
+        <button type='button' className='text-gray-500' onClick={handleClose}>
           <Image
             src={'/image/closeBtn.svg'}
             alt='닫힘버튼'
@@ -113,18 +149,10 @@ const DetailFilter: React.FC<DetailFilterProps> = ({ isVisible, onClose }) => {
       </div>
 
       <div className='flex gap-4'>
-        <Button
-          type='reset'
-          style='bordered'
-          size='sm'
-          onClick={() => {
-            setSelectedOptions([]);
-            setAmount('');
-            setStartDate('');
-          }}>
+        <Button type='reset' style='bordered' size='sm' onClick={handleReset}>
           초기화
         </Button>
-        <Button type='submit' size='lg'>
+        <Button type='button' size='lg' onClick={handleApply}>
           적용하기
         </Button>
       </div>

--- a/src/app/_components/Pagination.tsx
+++ b/src/app/_components/Pagination.tsx
@@ -1,18 +1,19 @@
 'use client';
 
-import { useState } from 'react';
+import React from 'react';
 import ArrowButton from './ArrowButton';
 
 interface PaginationProps {
   totalPages: number;
+  currentPage: number;
   onPageChange: (page: number) => void;
 }
 
 const Pagination: React.FC<PaginationProps> = ({
   totalPages,
+  currentPage,
   onPageChange,
 }) => {
-  const [currentPage, setCurrentPage] = useState(1);
   const pagesPerGroup = 7;
 
   const getPageGroup = () => {
@@ -26,7 +27,6 @@ const Pagination: React.FC<PaginationProps> = ({
 
   const goToPage = (page: number) => {
     if (page >= 1 && page <= totalPages) {
-      setCurrentPage(page);
       onPageChange(page);
     }
   };
@@ -41,7 +41,7 @@ const Pagination: React.FC<PaginationProps> = ({
       <ArrowButton
         direction='first'
         onClick={() => goToPage(1)}
-        isDisabled={start === 1}
+        isDisabled={currentPage === 1}
       />
 
       <ArrowButton
@@ -49,6 +49,7 @@ const Pagination: React.FC<PaginationProps> = ({
         onClick={() => goToPage(start - 1)}
         isDisabled={start <= 1}
       />
+
       {pageNumbers.map((page) => (
         <button
           key={page}
@@ -69,7 +70,7 @@ const Pagination: React.FC<PaginationProps> = ({
       <ArrowButton
         direction='last'
         onClick={() => goToPage(totalPages)}
-        isDisabled={start + pagesPerGroup > totalPages}
+        isDisabled={currentPage === totalPages}
       />
     </div>
   );

--- a/src/app/_components/PostCard/DetailPostCard.tsx
+++ b/src/app/_components/PostCard/DetailPostCard.tsx
@@ -1,66 +1,145 @@
 import Image from 'next/image';
-import clsx from 'clsx';
 import Badge from '../Badge';
 import Button from '../Button';
 
-const DetailPostCard = () => {
+interface DetailPostCard {
+  type?: 'store' | 'notice';
+  name: string;
+  startsAt?: string;
+  workhour?: number;
+  address1: string;
+  imageUrl: string;
+  hourlyPay?: number;
+  percent?: number;
+  shopDescription: string;
+  noticeDescription?: string;
+  closed?: boolean;
+  shopId?: string;
+  userId?: string;
+}
+
+const DetailPostCard: React.FC<DetailPostCard> = ({
+  type = 'notice',
+  name,
+  address1,
+  imageUrl,
+  shopDescription,
+  noticeDescription,
+  hourlyPay,
+  percent,
+  workhour,
+  startsAt,
+  closed,
+  shopId,
+  userId,
+}) => {
   return (
     <>
-      <div className='w-[345px] h-[450px] md:w-[680px] md:h-[677px] lg:w-[964px] lg:h-[356px] rounded-xl border p-5 md:p-6 flex flex-col lg:flex-row justify-between'>
-        <div className='w-[311px] h-[177px] md:w-[632px] md:h-[361px] lg:w-[539px] lg:h-[308px] relative flex-shrink-0'>
-          <Image
-            src='https://images.unsplash.com/photo-1731778572747-315c9089bc69?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxmZWF0dXJlZC1waG90b3MtZmVlZHw3fHx8ZW58MHx8fHx8'
-            alt=''
-            fill
-            className='object-cover'
-          />
-        </div>
-        <div className='flex flex-col justify-between w-[311px] h-[251px] md:w-[632px] md:h-[276px] lg:w-[346px] lg:h-[308px]'>
+      <div>
+        {/* 카드 제목 */}
+        {type === 'notice' ? (
           <div>
-            <h2 className='text-primary text-14b md:text-16b mb-2'>가게</h2>
-            <div className='flex items-center gap-2 mb-3'>
-              <span className='text-24b md:text-28b'>15,000원</span>
-              <Badge percent={50} />
-            </div>
-            <div className='flex mb-3'>
-              <div className='inline w-4 h-4 md:w-5 md:h-5'>
-                <Image
-                  src='./image/clock-icon.svg'
-                  alt='근무시간'
-                  width={20}
-                  height={20}
-                  className='w-4 h-4 md:w-5 md:h-5'
-                />
-              </div>
-              <p className='text-14 md:text-16 text-gray-500'>
-                2023-01-02 15:00~18:00 (3시간)
-              </p>
-            </div>
-            <div className='flex mb-3'>
-              <div className='inline w-4 h-4 md:w-5 md:h-5 flex justify-center'>
-                <Image
-                  src='./image/path11.svg'
-                  alt='주소'
-                  width={16}
-                  height={20}
-                  className='w-[13px] h-4 md:w-4 md:h-5'
-                />
-              </div>
-              <p className='text-14 md:text-16 text-gray-500'>서울시 송파구</p>
-            </div>
-            <div className='line-clamp-3 text-14 md:text-16'>
-              알바하기 편한 너구리네 라면집! 라면 올려두고 끓이기만 하면 되어서
-              쉬운 편에 속하는 가게입니다. 알바하기 편한 너구리네 라면집! 라면
-              올려두고 끓이기만 하면 되어서 쉬운 편에 속하는 가게입니다.
-              알바하기 편한 너구리네 라면집! 라면 올려두고 끓이기만 하면 되어서
-              쉬운 편에 속하는 가게입니다. 알바하기 편한 너구리네 라면집! 라면
-              올려두고 끓이기만 하면 되어서 쉬운 편에 속하는 가게입니다.
-            </div>
+            <h2 className='text-primary text-14b md:text-16b mb-2'>식당</h2>
+            <span className='text-20b md:text-28b'>{name}</span>
           </div>
-          <div>
-            <Button size='full'>공고모집</Button>
+        ) : (
+          <h2 className='text-20b md:text-28b'>내 가게</h2>
+        )}
+        {/* 카드 부분 */}
+        <div className='w-[345px] h-auto md:w-[680px] md:h-auto lg:w-[964px] lg:h-[356px] rounded-xl border p-5 md:p-6 flex flex-col lg:flex-row justify-between mt-4 md:mt-6'>
+          <div className='w-[311px] h-[177px] md:w-[632px] md:h-[361px] lg:w-[539px] lg:h-[308px] relative flex-shrink-0 rounded-xl overflow-hidden'>
+            <Image
+              src={imageUrl}
+              alt='가게 사진'
+              fill
+              className='object-cover'
+            />
+            {closed && (
+              <div className='absolute bg-black inset-0 opacity-70 flex justify-center items-center'>
+                <span className='text-20b md:text-28b text-gray-300'>
+                  마감 완료
+                </span>
+              </div>
+            )}
+          </div>
+          <div className='flex flex-col justify-between w-[311px] h-[251px] md:w-[632px] md:h-[276px] lg:w-[346px] lg:h-[308px] mt-4 lg:mt-0'>
+            <div>
+              <h2 className='text-primary text-14b md:text-16b mb-2'>
+                {type === 'notice' ? '시급' : '식당'}
+              </h2>
+              {type === 'notice' ? (
+                <div className='flex items-center gap-2 mb-3'>
+                  <span className='text-24b md:text-28b'>{hourlyPay}원</span>
+                  <Badge percent={percent} />
+                </div>
+              ) : (
+                <h2 className='text-24b md:text-28b'>{name}</h2>
+              )}
+              {type === 'notice' && (
+                <div className='flex mb-3 gap-2'>
+                  <div className='inline w-4 h-4 md:w-5 md:h-5'>
+                    <Image
+                      src='./image/clock-icon.svg'
+                      alt='근무시간'
+                      width={20}
+                      height={20}
+                      className='w-4 h-4 md:w-5 md:h-5'
+                    />
+                  </div>
+                  <p className='text-14 md:text-16 text-gray-500'>
+                    {startsAt} ({workhour})
+                  </p>
+                </div>
+              )}
+
+              <div className='flex mb-3 gap-2'>
+                <div className='inline w-4 h-4 md:w-5 md:h-5 flex justify-center'>
+                  <Image
+                    src='./image/path11.svg'
+                    alt='주소'
+                    width={16}
+                    height={20}
+                    className='w-[13px] h-4 md:w-4 md:h-5'
+                  />
+                </div>
+                <p className='text-14 md:text-16 text-gray-500'>{address1}</p>
+              </div>
+              <div className='line-clamp-3 text-14 md:text-16 md:line-clamp-2 lg:line-clamp-3'>
+                {shopDescription}
+              </div>
+            </div>
+            {type === 'notice' && (
+              <div>
+                {closed ? (
+                  <Button size='full' disabled>
+                    신청 불가
+                  </Button>
+                ) : userId === shopId ? (
+                  <Button size='full' style='bordered'>
+                    공고 편집하기
+                  </Button>
+                ) : (
+                  <Button size='full'>신청하기</Button>
+                )}
+              </div>
+            )}
+            {type === 'store' && (
+              <div className='flex gap-2'>
+                <Button size='full' style='bordered'>
+                  편집하기
+                </Button>
+                <Button size='full'>공고 등록하기</Button>
+              </div>
+            )}
           </div>
         </div>
+        {/* 카드 설명부분 */}
+        {type === 'notice' && (
+          <div className='mt-6 w-[345px] md:w-[680px] lg:w-[964px] h-auto rounded-xl bg-gray-100 p-5'>
+            <h3 className='text-14b md:text-16b'>공고 설명</h3>
+            <p className='text-14 md:text-16 mt-2'>{noticeDescription}</p>
+          </div>
+        )}
       </div>
     </>
   );

--- a/src/app/_components/PostCard/DetailPostCard.tsx
+++ b/src/app/_components/PostCard/DetailPostCard.tsx
@@ -1,0 +1,69 @@
+import Image from 'next/image';
+import clsx from 'clsx';
+import Badge from '../Badge';
+import Button from '../Button';
+
+const DetailPostCard = () => {
+  return (
+    <>
+      <div className='w-[345px] h-[450px] md:w-[680px] md:h-[677px] lg:w-[964px] lg:h-[356px] rounded-xl border p-5 md:p-6 flex flex-col lg:flex-row justify-between'>
+        <div className='w-[311px] h-[177px] md:w-[632px] md:h-[361px] lg:w-[539px] lg:h-[308px] relative flex-shrink-0'>
+          <Image
+            src='https://images.unsplash.com/photo-1731778572747-315c9089bc69?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxmZWF0dXJlZC1waG90b3MtZmVlZHw3fHx8ZW58MHx8fHx8'
+            alt=''
+            fill
+            className='object-cover'
+          />
+        </div>
+        <div className='flex flex-col justify-between w-[311px] h-[251px] md:w-[632px] md:h-[276px] lg:w-[346px] lg:h-[308px]'>
+          <div>
+            <h2 className='text-primary text-14b md:text-16b mb-2'>가게</h2>
+            <div className='flex items-center gap-2 mb-3'>
+              <span className='text-24b md:text-28b'>15,000원</span>
+              <Badge percent={50} />
+            </div>
+            <div className='flex mb-3'>
+              <div className='inline w-4 h-4 md:w-5 md:h-5'>
+                <Image
+                  src='./image/clock-icon.svg'
+                  alt='근무시간'
+                  width={20}
+                  height={20}
+                  className='w-4 h-4 md:w-5 md:h-5'
+                />
+              </div>
+              <p className='text-14 md:text-16 text-gray-500'>
+                2023-01-02 15:00~18:00 (3시간)
+              </p>
+            </div>
+            <div className='flex mb-3'>
+              <div className='inline w-4 h-4 md:w-5 md:h-5 flex justify-center'>
+                <Image
+                  src='./image/path11.svg'
+                  alt='주소'
+                  width={16}
+                  height={20}
+                  className='w-[13px] h-4 md:w-4 md:h-5'
+                />
+              </div>
+              <p className='text-14 md:text-16 text-gray-500'>서울시 송파구</p>
+            </div>
+            <div className='line-clamp-3 text-14 md:text-16'>
+              알바하기 편한 너구리네 라면집! 라면 올려두고 끓이기만 하면 되어서
+              쉬운 편에 속하는 가게입니다. 알바하기 편한 너구리네 라면집! 라면
+              올려두고 끓이기만 하면 되어서 쉬운 편에 속하는 가게입니다.
+              알바하기 편한 너구리네 라면집! 라면 올려두고 끓이기만 하면 되어서
+              쉬운 편에 속하는 가게입니다. 알바하기 편한 너구리네 라면집! 라면
+              올려두고 끓이기만 하면 되어서 쉬운 편에 속하는 가게입니다.
+            </div>
+          </div>
+          <div>
+            <Button size='full'>공고모집</Button>
+          </div>
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default DetailPostCard;

--- a/src/app/_components/PostCard/DetailPostCard.tsx
+++ b/src/app/_components/PostCard/DetailPostCard.tsx
@@ -1,6 +1,7 @@
 import Image from 'next/image';
 import Badge from '../Badge';
 import Button from '../Button';
+import clsx from 'clsx';
 
 interface DetailPostCard {
   type?: 'store' | 'notice';
@@ -46,7 +47,11 @@ const DetailPostCard: React.FC<DetailPostCard> = ({
           <h2 className='text-20b md:text-28b'>내 가게</h2>
         )}
         {/* 카드 부분 */}
-        <div className='w-[345px] h-auto md:w-[680px] md:h-auto lg:w-[964px] lg:h-[356px] rounded-xl border p-5 md:p-6 flex flex-col lg:flex-row justify-between mt-4 md:mt-6'>
+        <div
+          className={clsx(
+            'w-[345px] h-auto md:w-[680px] md:h-auto lg:w-[964px] lg:h-[356px] rounded-xl border p-5 md:p-6 flex flex-col lg:flex-row justify-between mt-4 md:mt-6',
+            { 'bg-red-10': type === 'store' },
+          )}>
           <div className='w-[311px] h-[177px] md:w-[632px] md:h-[361px] lg:w-[539px] lg:h-[308px] relative flex-shrink-0 rounded-xl overflow-hidden'>
             <Image
               src={imageUrl}

--- a/src/app/_components/PostCard/PostCard.tsx
+++ b/src/app/_components/PostCard/PostCard.tsx
@@ -10,8 +10,8 @@ interface PostCardProps {
   workhour?: string; // 근무 시간
   address1: string; // 주소1
   imageUrl: string; // 이미지 URL
-  originalHourlyPay?: number; // 시급
-  percent?: number; // 시급 변화 비율
+  hourlyPay: number; // 시급
+  originalHourlyPay?: number; //예전시급
   isPast?: boolean; //지난 공고 여부
 }
 
@@ -21,14 +21,19 @@ const PostCard: React.FC<PostCardProps> = ({
   workhour,
   address1,
   imageUrl,
+  hourlyPay,
   originalHourlyPay,
-  percent,
   isPast,
 }) => {
+  const percent =
+    originalHourlyPay !== undefined
+      ? Math.round(((hourlyPay - originalHourlyPay) / originalHourlyPay) * 100)
+      : undefined;
+
   return (
     <div
       className={clsx(
-        'w-[171px] h-[261px] md:w-[332px] md:h-[360px] lg:w-[312px] lg:h-[349px] gap-3 p-3 border border-gray-200 rounded-xl bg-white',
+        'w-[171px] h-auto md:w-[332px] md:h-[360px] lg:w-[312px] lg:h-[349px] gap-3 p-3 border border-gray-200 rounded-xl bg-white',
       )}>
       <div className='relative w-[147px] h-[84px] md:w-[300px] md:h-[171px] lg:w-[280px] lg:h-[160px] rounded-xl overflow-hidden'>
         <Image src={imageUrl} alt={name} fill className='object-cover' />
@@ -84,17 +89,17 @@ const PostCard: React.FC<PostCardProps> = ({
           </p>
         )}
         <div className='flex flex-col md:flex-row justify-between mt-3 md:mt-4'>
-          {originalHourlyPay !== undefined && (
-            <>
-              <h2
-                className={clsx(
-                  ' text-18b md:text-24b lg:text-24b',
-                  isPast ? 'text-gray-300' : 'text-black',
-                )}>
-                {originalHourlyPay.toLocaleString()}원
-              </h2>
+          <>
+            <h2
+              className={clsx(
+                ' text-18b md:text-24b lg:text-24b',
+                isPast ? 'text-gray-300' : 'text-black',
+              )}>
+              {hourlyPay.toLocaleString()}원
+            </h2>
+            {percent !== undefined && percent > 0 && (
               <p className='flex md:hidden text-12 text-red-30'>
-                기존 시급보다 {percent}{' '}
+                기존 시급보다 {percent}
                 <Image
                   src='/image/arrow-up-bold-red.svg'
                   alt='화살표 아이콘'
@@ -103,9 +108,9 @@ const PostCard: React.FC<PostCardProps> = ({
                   priority
                 />
               </p>
-            </>
-          )}
-          {percent !== undefined && (
+            )}
+          </>
+          {percent !== undefined && percent > 0 && (
             <div className='hidden md:block'>
               <Badge percent={percent} isPast={isPast} />
             </div>

--- a/src/app/_components/PostCard/PostCard.tsx
+++ b/src/app/_components/PostCard/PostCard.tsx
@@ -28,7 +28,7 @@ const PostCard: React.FC<PostCardProps> = ({
   return (
     <div
       className={clsx(
-        'w-[171px] h-[261px] md:w-[332px] md:h-[360px] lg:w-[312px] lg:h-[349px] gap-3 p-3 border border-gray-200 rounded-xl',
+        'w-[171px] h-[261px] md:w-[332px] md:h-[360px] lg:w-[312px] lg:h-[349px] gap-3 p-3 border border-gray-200 rounded-xl bg-white',
       )}>
       <div className='relative w-[147px] h-[84px] md:w-[300px] md:h-[171px] lg:w-[280px] lg:h-[160px] rounded-xl overflow-hidden'>
         <Image src={imageUrl} alt={name} fill className='object-cover' />

--- a/src/app/_components/PostCard/PostCard.tsx
+++ b/src/app/_components/PostCard/PostCard.tsx
@@ -30,12 +30,11 @@ const PostCard: React.FC<PostCardProps> = ({
       className={clsx(
         'w-[171px] h-[261px] md:w-[332px] md:h-[360px] lg:w-[312px] lg:h-[349px] gap-3 p-3 border border-gray-200 rounded-xl',
       )}>
-      
       <div className='relative w-[147px] h-[84px] md:w-[300px] md:h-[171px] lg:w-[280px] lg:h-[160px] rounded-xl overflow-hidden'>
-       <Image src={imageUrl} alt={name} layout='fill' objectFit='cover' />
+        <Image src={imageUrl} alt={name} fill className='object-cover' />
         {isPast && (
           <div className='absolute inset-0 flex justify-center items-center bg-opacity-70 bg-black'>
-             <span className='text-gray-300 inset-0 text-20b md:text-28b'>
+            <span className='text-gray-300 inset-0 text-20b md:text-28b'>
               지난 공고
             </span>
           </div>
@@ -49,7 +48,7 @@ const PostCard: React.FC<PostCardProps> = ({
           )}>
           {name}
         </h2>
-         {startsAt && workhour && (
+        {startsAt && workhour && (
           <p
             className={clsx(
               'flex items-center mt-2 text-12 md:text-14',
@@ -67,7 +66,7 @@ const PostCard: React.FC<PostCardProps> = ({
             {startsAt} ({workhour}시간)
           </p>
         )}
-          {address1 && (
+        {address1 && (
           <p
             className={clsx(
               'flex items-center mt-2 font-family text-12 md:text-14',
@@ -84,7 +83,7 @@ const PostCard: React.FC<PostCardProps> = ({
             {address1}
           </p>
         )}
-         <div className='flex flex-col md:flex-row justify-between mt-3 md:mt-4'>
+        <div className='flex flex-col md:flex-row justify-between mt-3 md:mt-4'>
           {originalHourlyPay !== undefined && (
             <>
               <h2

--- a/src/app/_components/PostCard/PostCard.tsx
+++ b/src/app/_components/PostCard/PostCard.tsx
@@ -3,16 +3,17 @@ import React from 'react';
 import clsx from 'clsx';
 import Badge from '../Badge'; // Badge 컴포넌트 가져오기
 import Image from 'next/image';
+import useAlbaTimeFormat from '@/app/_hooks/useAlbaTimeFormat';
 
 interface PostCardProps {
-  name: string; // 이름
-  startsAt?: string; // 시작하는 날짜
-  workhour?: string; // 근무 시간
-  address1: string; // 주소1
-  imageUrl: string; // 이미지 URL
-  hourlyPay: number; // 시급
-  originalHourlyPay?: number; //예전시급
-  isPast?: boolean; //지난 공고 여부
+  name: string;
+  startsAt?: string;
+  workhour?: string;
+  address1: string;
+  imageUrl: string;
+  hourlyPay: number;
+  originalHourlyPay?: number;
+  isPast?: boolean;
 }
 
 const PostCard: React.FC<PostCardProps> = ({
@@ -25,6 +26,7 @@ const PostCard: React.FC<PostCardProps> = ({
   originalHourlyPay,
   isPast,
 }) => {
+  const TimeFormat = useAlbaTimeFormat(startsAt, workhour);
   const percent =
     originalHourlyPay !== undefined
       ? Math.round(((hourlyPay - originalHourlyPay) / originalHourlyPay) * 100)
@@ -68,7 +70,7 @@ const PostCard: React.FC<PostCardProps> = ({
               height={20}
               className='mr-1'
             />
-            {startsAt} ({workhour}시간)
+            {TimeFormat} ({workhour}시간)
           </p>
         )}
         {address1 && (

--- a/src/app/_components/PostCard/PostCardV.1.tsx
+++ b/src/app/_components/PostCard/PostCardV.1.tsx
@@ -4,8 +4,7 @@ import clsx from 'clsx';
 import Button from '../Button';
 import Image from 'next/image';
 import { useWindowWidth } from '../../_hooks/useWindowWidth';
-import { useNavigate } from 'react-router-dom'; 
-
+import { useNavigate } from 'react-router-dom';
 
 interface PostCardProps {
   name: string; // 이름
@@ -19,117 +18,115 @@ const PostCard: React.FC<PostCardProps> = ({
   address1,
   imageUrl,
   description,
-
 }) => {
+  const windowWidth = useWindowWidth(); // 현재 창 너비 가져오기
+  const isDesktop = windowWidth >= 964;
+  const navigate = useNavigate();
 
-    const windowWidth = useWindowWidth(); // 현재 창 너비 가져오기
-    const isDesktop = windowWidth >= 964; 
-    const navigate = useNavigate();
+  if (isDesktop) {
+    // 데스크톱 레이아웃
+    return (
+      <div
+        className={clsx(
+          'w-full max-w-[964px] p-6 bg-red-10 border rounded-xl shadow-md flex flex-row gap-6',
+        )}>
+        {/* 이미지 */}
+        <div className='relative w-[539px] h-[308px] flex-shrink-0 rounded-xl overflow-hidden'>
+          <Image src={imageUrl} alt={name} layout='fill' objectFit='cover' />
+        </div>
 
-    if (isDesktop) {
-      // 데스크톱 레이아웃
-      return (
-        <div
-          className={clsx(
-            'w-full max-w-[964px] p-6 bg-red-10 border rounded-xl shadow-md flex flex-row gap-6'
-          )}>
-
-          {/* 이미지 */}
-          <div className='relative w-[539px] h-[308px] flex-shrink-0 rounded-xl overflow-hidden'>
-            <Image src={imageUrl} alt={name} layout='fill' objectFit='cover' />
-          </div>
-  
-          {/* 텍스트 */}
-          <div className='flex-1 flex flex-col justify-between mt-6'>
-            <div>
-              <p className='text-16b text-primary'>식당</p>
-              <h2 className="mt-2 text-28b text-black">{name}</h2>
-                {/* 주소 */}
-              {address1 && (
-                <p className='flex items-center mt-2 text-16 text-gray-500'>
-                  <Image
-                    src='./image/path11.svg'
-                    alt='주소 아이콘'
-                    width={20}
-                    height={20}
-                    className='mr-1'
-                  />
-                  {address1}
-                </p>
-              )}
-              {/* 상세 설명 */}
-              <p className='mt-4 line-clamp-4 text-black text-16 leading-relaxed'>
-                {description}
+        {/* 텍스트 */}
+        <div className='flex-1 flex flex-col justify-between mt-6'>
+          <div>
+            <p className='text-16b text-primary'>식당</p>
+            <h2 className='mt-2 text-28b text-black'>{name}</h2>
+            {/* 주소 */}
+            {address1 && (
+              <p className='flex items-center mt-2 text-16 text-gray-500'>
+                <Image
+                  src='./image/path11.svg'
+                  alt='주소 아이콘'
+                  width={20}
+                  height={20}
+                  className='mr-1'
+                />
+                {address1}
               </p>
-            </div>
-            <div className ='flex justify-end gap-4 '>
+            )}
+            {/* 상세 설명 */}
+            <p className='mt-4 line-clamp-4 text-black text-16 leading-relaxed'>
+              {description}
+            </p>
+          </div>
+          <div className='flex justify-end gap-4 '>
             {/* 버튼 */}
             <Button
               style='bordered'
               size='full'
               className='text-16b bg-white'
-              onClick={() => navigate('/edit')}> {/* 경로 수정 */}
+              onClick={() => navigate('/edit')}>
+              {' '}
+              {/* 경로 수정 */}
               편집하기
             </Button>
-            <Button 
-            style="default" 
+            <Button
+              style='default'
+              size='full'
+              className='text-16b'
+              onClick={() => navigate('/register')}>
+              {' '}
+              {/* 경로 수정 */}
+              공고 등록하기
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className='w-[351px] h-auto md:w-[680px] md:h-[677px] p-3 md:p-4 bg-red-10 border border-gray-200 rounded-xl shadow-md'>
+      <div className='relative w-full h-[200px]  md:h-[360px] rounded-xl overflow-hidden'>
+        <Image src={imageUrl} alt={name} layout='fill' objectFit='cover' />
+      </div>
+      <div>
+        <h1 className='text-14b text-primary md:text-16b mt-2'>식당</h1>
+        <h2 className='mt-2 text-24b text-black md:text-28b'>{name}</h2>
+        <p className='flex items-center mt-2 text-14 text-gray-500'>
+          <Image
+            src='./image/path11.svg'
+            alt='주소 아이콘'
+            width={16}
+            height={16}
+            className='mr-1'
+          />
+          {address1}
+        </p>
+        <p className='mt-2 text-14  text-black'>{description}</p>
+        <div className='flex justify-between mt-4'>
+          <Button
+            type='button'
+            style='bordered'
+            size='full'
+            className='text-16b bg-white'
+            onClick={() => navigate('/edit')}>
+            {' '}
+            {/* 경로 수정 */}
+            편집하기
+          </Button>
+          <Button
+            type='button'
+            style='default'
             size='full'
             className='text-16b'
-            onClick={() => navigate('/register')}> {/* 경로 수정 */}
-          공고 등록하기
-        </Button>
-            </div>
-          </div>
-              </div>
-          );
-        };
-        return (
-          <div className="w-[351px] h-auto md:w-[680px] md:h-[677px] p-3 md:p-4 bg-red-10 border border-gray-200 rounded-xl shadow-md">
-            <div className='relative w-full h-[200px]  md:h-[360px] rounded-xl overflow-hidden'>
-              <Image
-                src={imageUrl}
-                alt={name}
-                layout='fill'
-                objectFit='cover'
-                />
-            </div>
-            <div>
-            <h1 className='text-14b text-primary md:text-16b mt-2'>식당</h1>
-            <h2 className="mt-2 text-24b text-black md:text-28b">{name}</h2>
-            <p className= 'flex items-center mt-2 text-14 text-gray-500'>
-                <Image
-                  src='./image/path11.svg'
-                  alt='주소 아이콘'
-                  width={16}
-                  height={16}
-                  className='mr-1'
-                />
-                {address1}
-              </p>
-            <p className="mt-2 text-14  text-black">{description}</p>
-            <div className="flex justify-between mt-4">
+            onClick={() => navigate('/register')}>
+            {' '}
+            {/* 경로 수정 */}
+            공고 등록하기
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+};
 
-            <Button
-                type='button'
-                style='bordered'
-                size='full'
-                className='text-16b bg-white'
-                onClick={() => navigate('/edit')}> {/* 경로 수정 */}
-                편집하기
-              </Button>
-              <Button 
-                type='button'
-                style="default" 
-                size='full'
-                className='text-16b'
-                onClick={() => navigate('/register')}> {/* 경로 수정 */}
-                공고 등록하기
-              </Button>
-              </div>
-            </div>
-          </div>
-        );
-      };
-            
-
-export default PostCard
+export default PostCard;

--- a/src/app/_components/header.tsx
+++ b/src/app/_components/header.tsx
@@ -16,8 +16,6 @@ const Header = () => {
   const windowWidth = useWindowWidth();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
-  console.log(user);
-
   // 알림 상태 가져오기
   const isNotificationActive = useNotifications();
 

--- a/src/app/_components/header.tsx
+++ b/src/app/_components/header.tsx
@@ -16,6 +16,8 @@ const Header = () => {
   const windowWidth = useWindowWidth();
   const [isModalOpen, setIsModalOpen] = useState(false);
 
+  console.log(user);
+
   // 알림 상태 가져오기
   const isNotificationActive = useNotifications();
 

--- a/src/app/_context/AppContext.tsx
+++ b/src/app/_context/AppContext.tsx
@@ -1,8 +1,13 @@
 import React from 'react';
 import { AuthProvider } from './AuthContext';
+import { NoticeProvider } from './NoticeContext';
 
 export const AppProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
-  return <AuthProvider>{children}</AuthProvider>;
+  return (
+    <AuthProvider>
+      <NoticeProvider>{children}</NoticeProvider>
+    </AuthProvider>
+  );
 };

--- a/src/app/_context/AuthContext.tsx
+++ b/src/app/_context/AuthContext.tsx
@@ -4,6 +4,7 @@ import React, { createContext, useState, useEffect } from 'react';
 import { jwtDecode } from 'jwt-decode';
 import { setGlobalToken } from '../_api/globaltoken';
 import { encryptData, decryptData } from './util/authEncryption';
+import { useRouter } from 'next/navigation';
 
 interface AuthContextProps {
   token: string | null;
@@ -21,6 +22,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
 }) => {
   const [token, setToken] = useState<string | null>(null);
   const [user, setUser] = useState<User | null>(null);
+  const router = useRouter();
 
   useEffect(() => {
     const encryptedData = localStorage.getItem('julge');
@@ -60,6 +62,7 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({
     setToken(null);
     setUser(null);
     localStorage.removeItem('julge');
+    router.push('/');
   };
 
   return (

--- a/src/app/_context/NoticeContext.tsx
+++ b/src/app/_context/NoticeContext.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { createContext, useState, useEffect, useCallback } from 'react';
-import { usePathname } from 'next/navigation'; // usePathname 사용
+import { usePathname } from 'next/navigation';
 import { getNotices } from '../_api/announce_api';
 
 interface Notice {

--- a/src/app/_context/NoticeContext.tsx
+++ b/src/app/_context/NoticeContext.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import React, { createContext, useState, useEffect, useCallback } from 'react';
+import { usePathname } from 'next/navigation'; // usePathname 사용
+import { getNotices } from '../_api/announce_api';
+
+interface Notice {
+  id: string;
+  hourlyPay: number;
+  startsAt: string;
+  workhour: number;
+  description: string;
+  closed: boolean;
+  shop: {
+    item: {
+      id: string;
+      name: string;
+      category: string;
+      address1: string;
+      address2: string;
+      description: string;
+      imageUrl: string;
+      originalHourlyPay: number;
+    };
+    href: string;
+  };
+}
+
+interface NoticeContextProps {
+  notices: Notice[];
+  totalCount: number;
+}
+
+export const NoticeContext = createContext<NoticeContextProps | undefined>(
+  undefined,
+);
+
+export const NoticeProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [notices, setNotices] = useState<Notice[]>([]);
+  const [totalCount, setTotalCount] = useState<number>(0);
+  const pathname = usePathname();
+
+  console.log(notices);
+
+  const fetchAllNotices = useCallback(async () => {
+    let allNotices: Notice[] = [];
+    let offset = 0;
+    const limit = 100;
+    let hasNext = true;
+
+    while (hasNext) {
+      try {
+        const response = await getNotices(offset, limit);
+        const data = response.data;
+
+        allNotices = [
+          ...allNotices,
+          ...data.items.map((item: any) => item.item),
+        ];
+        hasNext = data.hasNext;
+        offset += limit;
+      } catch (error) {
+        console.error('공고 데이터 가져오기 실패:', error);
+        break;
+      }
+    }
+
+    setNotices(allNotices);
+    setTotalCount(allNotices.length);
+  }, []);
+
+  useEffect(() => {
+    if (pathname === '/') {
+      fetchAllNotices();
+    }
+  }, [pathname, fetchAllNotices]);
+
+  return (
+    <NoticeContext.Provider value={{ notices, totalCount }}>
+      {children}
+    </NoticeContext.Provider>
+  );
+};

--- a/src/app/_hooks/useAlbaTimeFormat.ts
+++ b/src/app/_hooks/useAlbaTimeFormat.ts
@@ -1,0 +1,39 @@
+'use client';
+import { useMemo } from 'react';
+
+const useAlbaTimeFormat = (startsAt?: string, workhour?: string) => {
+  const formattedTime = useMemo(() => {
+    // 입력 값이 없을 경우 빈 문자열 반환
+    if (!startsAt || !workhour) return '';
+
+    // 날짜 및 시간 객체 생성
+    const startDate = new Date(startsAt);
+
+    // 시작 시간 계산
+    const startHours = startDate.getHours();
+    const startMinutes = startDate.getMinutes();
+
+    // 종료 시간 계산
+    const endHours = startHours + parseInt(workhour, 10);
+    const endMinutes = startMinutes;
+
+    // 날짜 포맷팅
+    const formattedDate = `${startDate.getFullYear()}-${String(
+      startDate.getMonth() + 1,
+    ).padStart(2, '0')}-${String(startDate.getDate()).padStart(2, '0')}`;
+
+    // 시간 포맷팅
+    const formattedStartTime = `${String(startHours).padStart(2, '0')}:${String(
+      startMinutes,
+    ).padStart(2, '0')}`;
+    const formattedEndTime = `${String(endHours).padStart(2, '0')}:${String(
+      endMinutes,
+    ).padStart(2, '0')}`;
+
+    return `${formattedDate} ${formattedStartTime}~${formattedEndTime}`;
+  }, [startsAt, workhour]);
+
+  return formattedTime;
+};
+
+export default useAlbaTimeFormat;

--- a/src/app/_hooks/useCreateImgUrl.ts
+++ b/src/app/_hooks/useCreateImgUrl.ts
@@ -14,23 +14,13 @@ export const useCreateImgUrl = () => {
     setError(null);
 
     try {
-      // 파일 압축
       const compressed = await compressFile(file);
-      console.log('발급전', compressed);
-      // Presigned URL 발급
       const presignedUrl = await createPresignedUrl(compressed.name);
-      console.log('발급후', compressed);
-      console.log(presignedUrl);
 
-      // S3에 업로드
       await uploadToS3(presignedUrl, compressed);
 
-      //쿼리마라미터 떼버리기
       const cleanUrl = presignedUrl.split('?')[0];
-      console.log('안뗸거', presignedUrl);
-      console.log('뗀거', cleanUrl);
 
-      // 업로드된 URL 저장
       setUploadedUrl(cleanUrl);
 
       return cleanUrl;

--- a/src/app/_hooks/useImageCompressor.ts
+++ b/src/app/_hooks/useImageCompressor.ts
@@ -15,24 +15,19 @@ const useImageCompressor = (): UseImageCompressorReturn => {
   const compressFile = async (file: File): Promise<File> => {
     try {
       const options = {
-        maxSizeMB: 0.5, // 최대 파일 크기 (MB)
-        maxWidthOrHeight: 1024, // 최대 가로/세로 길이 (픽셀)
-        useWebWorker: true, // Web Worker 사용
+        maxSizeMB: 0.5,
+        maxWidthOrHeight: 1024,
+        useWebWorker: true,
       };
 
       console.log(file);
 
-      // 이미지 압축
       const compressed = await imageCompression(file, options);
 
-      // 디버깅용 로그
-      console.log('압축된 파일:', compressed);
-
-      // 상태 업데이트
       setCompressedFile(compressed);
       setCompressedImage(URL.createObjectURL(compressed));
 
-      return compressed; // 압축된 파일 반환
+      return compressed;
     } catch (error) {
       console.error('이미지 압축 중 에러 발생:', error);
       throw new Error('이미지 압축 실패');

--- a/src/app/_hooks/useMouseDrag.ts
+++ b/src/app/_hooks/useMouseDrag.ts
@@ -1,0 +1,37 @@
+import { useRef, useCallback } from 'react';
+
+const useMouseDrag = () => {
+  const scrollRef = useRef<HTMLDivElement | null>(null);
+  const isDragging = useRef(false);
+  const startX = useRef(0);
+  const scrollLeft = useRef(0);
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    isDragging.current = true;
+    startX.current = e.pageX - (scrollRef.current?.offsetLeft || 0);
+    scrollLeft.current = scrollRef.current?.scrollLeft || 0;
+  }, []);
+
+  const handleMouseMove = useCallback((e: React.MouseEvent) => {
+    if (!isDragging.current) return;
+    e.preventDefault();
+    const x = e.pageX - (scrollRef.current?.offsetLeft || 0);
+    const walk = (x - startX.current) * 1; // 스크롤 속도
+    if (scrollRef.current) {
+      scrollRef.current.scrollLeft = scrollLeft.current - walk;
+    }
+  }, []);
+
+  const handleMouseUpOrLeave = useCallback(() => {
+    isDragging.current = false;
+  }, []);
+
+  return {
+    scrollRef,
+    handleMouseDown,
+    handleMouseMove,
+    handleMouseUpOrLeave,
+  };
+};
+
+export default useMouseDrag;

--- a/src/app/announce/_components/AllNotices.tsx
+++ b/src/app/announce/_components/AllNotices.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const AllNotices = () => {
+  return <div></div>;
+};
+
+export default AllNotices;

--- a/src/app/announce/_components/AllNotices.tsx
+++ b/src/app/announce/_components/AllNotices.tsx
@@ -1,13 +1,22 @@
 'use client';
 
-import React, { useContext, useState } from 'react';
+import React, { useContext, useState, useMemo } from 'react';
 import PostCard from '@/app/_components/PostCard/PostCard';
 import Pagination from '@/app/_components/Pagination';
 import { NoticeContext } from '@/app/_context/NoticeContext';
+import Dropdown from '@/app/_components/Dropdown';
+
+const options = ['마감임박순', '시급많은순', '시간적은순', '가나다순'];
 
 const AllNotices = () => {
   const context = useContext(NoticeContext);
   const [currentPage, setCurrentPage] = useState(1);
+  const [selectedOption, setSelectedOption] = useState<string | undefined>();
+
+  const handleOptionChange = (value: string) => {
+    setSelectedOption(value);
+    setCurrentPage(1);
+  };
 
   if (!context) {
     return <p>로딩바만들예정</p>;
@@ -15,11 +24,33 @@ const AllNotices = () => {
 
   const { notices } = context;
 
-  const postsPerPage = 6;
-  const totalPages = Math.ceil(notices.length / postsPerPage);
+  const filteredNotices = useMemo(() => {
+    switch (selectedOption) {
+      case '마감임박순':
+        return [...notices].sort(
+          (a, b) =>
+            new Date(a.startsAt).getTime() - new Date(b.startsAt).getTime(),
+        );
+      case '시급많은순':
+        return [...notices].sort((a, b) => b.hourlyPay - a.hourlyPay);
+      case '시간적은순':
+        return [...notices].sort((a, b) => a.workhour - b.workhour);
+      case '가나다순':
+        return [...notices].sort((a, b) =>
+          a.shop.item.name.localeCompare(b.shop.item.name),
+        );
+      default:
+        return notices;
+    }
+  }, [notices, selectedOption]);
 
+  const postsPerPage = 6;
+  const totalPages = Math.ceil(filteredNotices.length / postsPerPage);
   const startIndex = (currentPage - 1) * postsPerPage;
-  const currentPosts = notices.slice(startIndex, startIndex + postsPerPage);
+  const currentPosts = filteredNotices.slice(
+    startIndex,
+    startIndex + postsPerPage,
+  );
 
   const handlePageChange = (page: number) => {
     setCurrentPage(page);
@@ -28,9 +59,22 @@ const AllNotices = () => {
   return (
     <section className='w-full flex flex-col items-center py-10 md:py-[60px] px-3 md:px-8'>
       <div className='w-[351px] md:w-[679px] lg:w-[964px] max-w-screen-xl flex flex-col items-center'>
-        <div className='w-full flex justify-between mb-4'>
+        <div className='w-full flex flex-col md:flex-row justify-between mb-4'>
           <h2 className='text-20b md:text-28b'>전체 공고</h2>
-          <button className='text-blue-500 hover:underline'>전체 보기</button>
+          <div className='flex gap-3 mt-3'>
+            <div>
+              <Dropdown
+                options={options}
+                label=''
+                value={selectedOption}
+                onChange={handleOptionChange}
+                className='w-auto min-w-[120px] h-[54px] md:h-[66px] text-14b border-none'
+              />
+            </div>
+            <div className='h-[34px] w-20 flex justify-center items-center cursor-pointer bg-red-30 text-white rounded-[5px]'>
+              상세 필터
+            </div>
+          </div>
         </div>
 
         <div className='grid grid-cols-2 lg:grid-cols-3 w-full gap-1 md:gap-[14px]'>
@@ -50,7 +94,11 @@ const AllNotices = () => {
         </div>
 
         <div className='mt-6'>
-          <Pagination totalPages={totalPages} onPageChange={handlePageChange} />
+          <Pagination
+            currentPage={currentPage}
+            totalPages={totalPages}
+            onPageChange={handlePageChange}
+          />
         </div>
       </div>
     </section>

--- a/src/app/announce/_components/AllNotices.tsx
+++ b/src/app/announce/_components/AllNotices.tsx
@@ -1,7 +1,60 @@
-import React from 'react';
+'use client';
+
+import React, { useContext, useState } from 'react';
+import PostCard from '@/app/_components/PostCard/PostCard';
+import Pagination from '@/app/_components/Pagination';
+import { NoticeContext } from '@/app/_context/NoticeContext';
 
 const AllNotices = () => {
-  return <div></div>;
+  const context = useContext(NoticeContext);
+  const [currentPage, setCurrentPage] = useState(1);
+
+  if (!context) {
+    return <p>로딩바만들예정</p>;
+  }
+
+  const { notices } = context;
+
+  const postsPerPage = 6;
+  const totalPages = Math.ceil(notices.length / postsPerPage);
+
+  const startIndex = (currentPage - 1) * postsPerPage;
+  const currentPosts = notices.slice(startIndex, startIndex + postsPerPage);
+
+  const handlePageChange = (page: number) => {
+    setCurrentPage(page);
+  };
+
+  return (
+    <section className='w-full flex flex-col items-center py-10 md:py-[60px] px-3 md:px-8'>
+      <div className='w-[351px] md:w-[679px] lg:w-[964px] max-w-screen-xl flex flex-col items-center'>
+        <div className='w-full flex justify-between mb-4'>
+          <h2 className='text-20b md:text-28b'>전체 공고</h2>
+          <button className='text-blue-500 hover:underline'>전체 보기</button>
+        </div>
+
+        <div className='grid grid-cols-2 lg:grid-cols-3 w-full gap-1 md:gap-[14px]'>
+          {currentPosts.map((post) => (
+            <PostCard
+              key={post.id}
+              name={post.shop.item.name}
+              startsAt={post.startsAt}
+              workhour={post.workhour.toString()}
+              address1={post.shop.item.address1}
+              imageUrl={post.shop.item.imageUrl}
+              hourlyPay={post.hourlyPay}
+              originalHourlyPay={post.shop.item.originalHourlyPay}
+              isPast={post.closed}
+            />
+          ))}
+        </div>
+
+        <div className='mt-6'>
+          <Pagination totalPages={totalPages} onPageChange={handlePageChange} />
+        </div>
+      </div>
+    </section>
+  );
 };
 
 export default AllNotices;

--- a/src/app/announce/_components/UserNotice.tsx
+++ b/src/app/announce/_components/UserNotice.tsx
@@ -1,22 +1,42 @@
 'use client';
 
-import React from 'react';
+import React, { useContext } from 'react';
 import useMouseDrag from '@/app/_hooks/useMouseDrag';
+import { NoticeContext } from '@/app/_context/NoticeContext';
 import PostCard from '@/app/_components/PostCard/PostCard';
+
+const shuffleArray = (array: any[]) => {
+  const shuffled = [...array];
+  for (let i = shuffled.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [shuffled[i], shuffled[j]] = [shuffled[j], shuffled[i]];
+  }
+  return shuffled;
+};
 
 const UserNotice = () => {
   const { scrollRef, handleMouseDown, handleMouseMove, handleMouseUpOrLeave } =
     useMouseDrag();
+  const context = useContext(NoticeContext);
+
+  if (!context) {
+    return <p>로딩바 만들예정</p>;
+  }
+
+  const { notices } = context;
+
+  const randomNotices = shuffleArray(notices).slice(
+    0,
+    Math.min(3, notices.length),
+  );
 
   return (
     <section className='w-full h-[381px] md:h-[535px] bg-red-10 flex justify-center items-center py-10 md:py-[60px] px-3'>
       <div className='w-full max-w-screen-xl flex flex-col items-center'>
-        {/* 제목 */}
         <div className='w-full max-w-[521px] md:max-w-[964px] flex justify-start mb-4'>
           <h2 className='text-20b md:text-28b'>맞춤 공고</h2>
         </div>
 
-        {/* 카드 리스트 */}
         <div
           ref={scrollRef}
           className='w-full max-w-[521px] md:max-w-[964px] overflow-x-auto no-scrollbar cursor-grab'
@@ -25,9 +45,18 @@ const UserNotice = () => {
           onMouseUp={handleMouseUpOrLeave}
           onMouseLeave={handleMouseUpOrLeave}>
           <div className='flex space-x-4'>
-            <PostCard />
-            <PostCard />
-            <PostCard />
+            {randomNotices.map((notice) => (
+              <PostCard
+                key={notice.id}
+                name={notice.shop.item.name}
+                address1={notice.shop.item.address1}
+                startsAt={notice.startsAt}
+                imageUrl={notice.shop.item.imageUrl}
+                originalHourlyPay={notice.shop.item.originalHourlyPay}
+                hourlyPay={notice.hourlyPay}
+                workhour={notice.workhour}
+              />
+            ))}
           </div>
         </div>
       </div>

--- a/src/app/announce/_components/UserNotice.tsx
+++ b/src/app/announce/_components/UserNotice.tsx
@@ -31,7 +31,7 @@ const UserNotice = () => {
   );
 
   return (
-    <section className='w-full h-[381px] md:h-[535px] bg-red-10 flex justify-center items-center py-10 md:py-[60px] px-3'>
+    <section className='w-full h-[381px] md:h-[535px] bg-red-10 flex justify-center items-center py-10 md:py-[60px] px-3 md:px-8'>
       <div className='w-full max-w-screen-xl flex flex-col items-center'>
         <div className='w-full max-w-[521px] md:max-w-[964px] flex justify-start mb-4'>
           <h2 className='text-20b md:text-28b'>맞춤 공고</h2>
@@ -44,7 +44,7 @@ const UserNotice = () => {
           onMouseMove={handleMouseMove}
           onMouseUp={handleMouseUpOrLeave}
           onMouseLeave={handleMouseUpOrLeave}>
-          <div className='flex space-x-4'>
+          <div className='flex gap-1 md:gap-[14px]'>
             {randomNotices.map((notice) => (
               <PostCard
                 key={notice.id}

--- a/src/app/announce/_components/UserNotice.tsx
+++ b/src/app/announce/_components/UserNotice.tsx
@@ -1,0 +1,38 @@
+'use client';
+
+import React from 'react';
+import useMouseDrag from '@/app/_hooks/useMouseDrag';
+import PostCard from '@/app/_components/PostCard/PostCard';
+
+const UserNotice = () => {
+  const { scrollRef, handleMouseDown, handleMouseMove, handleMouseUpOrLeave } =
+    useMouseDrag();
+
+  return (
+    <section className='w-full h-[381px] md:h-[535px] bg-red-10 flex justify-center items-center py-10 md:py-[60px] px-3'>
+      <div className='w-full max-w-screen-xl flex flex-col items-center'>
+        {/* 제목 */}
+        <div className='w-full max-w-[521px] md:max-w-[964px] flex justify-start mb-4'>
+          <h2 className='text-20b md:text-28b'>맞춤 공고</h2>
+        </div>
+
+        {/* 카드 리스트 */}
+        <div
+          ref={scrollRef}
+          className='w-full max-w-[521px] md:max-w-[964px] overflow-x-auto no-scrollbar cursor-grab'
+          onMouseDown={handleMouseDown}
+          onMouseMove={handleMouseMove}
+          onMouseUp={handleMouseUpOrLeave}
+          onMouseLeave={handleMouseUpOrLeave}>
+          <div className='flex space-x-4'>
+            <PostCard />
+            <PostCard />
+            <PostCard />
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default UserNotice;

--- a/src/app/announce/detail/[id]/page.tsx
+++ b/src/app/announce/detail/[id]/page.tsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+const page = () => {
+  return <div></div>;
+};
+
+export default page;

--- a/src/app/announce/page.tsx
+++ b/src/app/announce/page.tsx
@@ -1,18 +1,18 @@
-"use client";
+'use client';
 
-import React, { useState } from "react";
-import Header from "@/app/_components/header";
-import Footer from "@/app/_components/footer";
-import { AuthProvider } from "@/app/_context/AuthContext";
-import PostCard from "@/app/_components/PostCard/PostCard";
-import DetailFilter from "@/app/_components/DetailFilter";
-import Pagination from "@/app/_components/Pagination";
-import Dropdown from "@/app/_components/Dropdown";
-import Button from "@/app/_components/Button";
-import Link from "next/link"; // Link 컴포넌트 추가
+import React, { useState } from 'react';
+import Header from '@/app/_components/Header';
+import Footer from '@/app/_components/Footer';
+import { AuthProvider } from '@/app/_context/AuthContext';
+import PostCard from '@/app/_components/PostCard/PostCard';
+import DetailFilter from '@/app/_components/DetailFilter';
+import Pagination from '@/app/_components/Pagination';
+import Dropdown from '@/app/_components/Dropdown';
+import Button from '@/app/_components/Button';
+import Link from 'next/link'; // Link 컴포넌트 추가
 
 const JobListPage = () => {
-  const [sortOption, setSortOption] = useState("마감임박순");
+  const [sortOption, setSortOption] = useState('마감임박순');
   const [currentPage, setCurrentPage] = useState(1);
   const [isDetailFilterVisible, setIsDetailFilterVisible] = useState(false); // 상세 필터 상태
   const totalPages = 7;
@@ -35,20 +35,24 @@ const JobListPage = () => {
 
   return (
     <AuthProvider>
-      <div className="flex flex-col">
+      <div className='flex flex-col'>
         <Header />
-        <main className="flex-grow">
-          <div className="container mx-auto py-8 px-4">
+        <main className='flex-grow'>
+          <div className='container mx-auto py-8 px-4'>
             {/* 맞춤 공고 */}
-            <section className="mb-12 bg-red-10 p-6 rounded-md"> {/* 맞춤 공고 배경색 */}
-              <h2 className="text-28b text-black mb-6">맞춤 공고</h2>
-              <div className="grid grid-cols-3 gap-4"> 
+            <section className='mb-12 bg-red-10 p-6 rounded-md'>
+              {' '}
+              {/* 맞춤 공고 배경색 */}
+              <h2 className='text-28b text-black mb-6'>맞춤 공고</h2>
+              <div className='grid grid-cols-3 gap-4'>
                 {[1, 2, 3].map((id) => (
-                  <Link key={id} href={`/announce/detail/${id}`}> {/* 맞춤 공고 상세 페이지로 이동 */}
+                  <Link key={id} href={`/announce/detail/${id}`}>
+                    {' '}
+                    {/* 맞춤 공고 상세 페이지로 이동 */}
                     <PostCard
                       name={`맞춤 공고 ${id}`}
-                      address1="서울시 강남구"
-                      imageUrl="/image/default.jpg"
+                      address1='서울시 강남구'
+                      imageUrl='/image/default.jpg'
                       originalHourlyPay={15000}
                       percent={50}
                     />
@@ -58,54 +62,53 @@ const JobListPage = () => {
             </section>
 
             {/* 전체 공고 */}
-            <section className="bg-white p-6 rounded-md"> {/* 전체 공고 배경색 */}
-              <div className="flex justify-between items-center mb-6 gap-4"> 
-                
+            <section className='bg-white p-6 rounded-md'>
+              {' '}
+              {/* 전체 공고 배경색 */}
+              <div className='flex justify-between items-center mb-6 gap-4'>
                 <Dropdown
-                  options={["마감임박순", "최신순", "높은가격순", "낮은가격순"]}
+                  options={['마감임박순', '최신순', '높은가격순', '낮은가격순']}
                   value={sortOption}
-                  label=""
+                  label=''
                   onChange={handleSortChange}
-                  placeholder="정렬 기준 선택"
+                  placeholder='정렬 기준 선택'
                 />
 
-               
-                <Button
-                  style="bordered"
-                  size="lg"
-                  onClick={toggleDetailFilter}>
+                <Button style='bordered' size='lg' onClick={toggleDetailFilter}>
                   상세 필터
                 </Button>
               </div>
-
               {/* 상세 필터 */}
               {isDetailFilterVisible && (
-                <div className="mb-6">
+                <div className='mb-6'>
                   <DetailFilter
                     isVisible={isDetailFilterVisible}
                     onClose={closeDetailFilter}
                   />
                 </div>
               )}
-
-              <h2 className="text-28b text-black mb-6">전체 공고</h2>
-              <div className="grid grid-cols-3 gap-4"> 
+              <h2 className='text-28b text-black mb-6'>전체 공고</h2>
+              <div className='grid grid-cols-3 gap-4'>
                 {Array.from({ length: 6 }, (_, i) => i + 1).map((id) => (
-                  <Link key={id} href={`/announce/detail/${id}`}> {/* 전체 공고 상세 페이지로 이동 */}
+                  <Link key={id} href={`/announce/detail/${id}`}>
+                    {' '}
+                    {/* 전체 공고 상세 페이지로 이동 */}
                     <PostCard
                       name={`전체 공고 ${id}`}
-                      address1="서울시 송파구"
-                      imageUrl="/image/default.jpg"
+                      address1='서울시 송파구'
+                      imageUrl='/image/default.jpg'
                       originalHourlyPay={10000}
                       percent={30}
                     />
                   </Link>
                 ))}
               </div>
-
               {/* 페이지 네이션 중앙 정렬 */}
-              <div className="mt-8 flex justify-center">
-                <Pagination totalPages={totalPages} onPageChange={handlePageChange} />
+              <div className='mt-8 flex justify-center'>
+                <Pagination
+                  totalPages={totalPages}
+                  onPageChange={handlePageChange}
+                />
               </div>
             </section>
           </div>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -54,3 +54,12 @@ input[type='number'].no-spinner::-webkit-inner-spin-button {
   -webkit-appearance: none;
   margin: 0;
 }
+
+.no-scrollbar {
+  scrollbar-width: none;
+  -ms-overflow-style: none;
+}
+
+.no-scrollbar::-webkit-scrollbar {
+  display: none;
+}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -42,6 +42,7 @@ const Login = () => {
         token: response.data.item.token,
         user: response.data.item.user.item,
       });
+
       router.push('/');
     } catch (error: any) {
       let errorMessage = '로그인에 실패했습니다 잠시 후 다시 시도해주세요.';

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -42,7 +42,6 @@ const Login = () => {
         token: response.data.item.token,
         user: response.data.item.user.item,
       });
-
       router.push('/');
     } catch (error: any) {
       let errorMessage = '로그인에 실패했습니다 잠시 후 다시 시도해주세요.';

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -9,7 +9,9 @@ export default function Home() {
   return (
     <div>
       <Header />
+      {/* 맞춤공고 */}
       <UserNotice />
+      {/* 전체공고 */}
       <AllNotices />
       <Footer />
     </div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,41 +1,11 @@
 'use client';
 
-import { useEffect } from 'react';
 import Header from './_components/Header';
-import { useAuth } from './_hooks/useAuth';
-import { getUserInfo } from './_api/worker_api';
-import { getNotices } from './_api/announce_api';
 import Footer from './_components/Footer';
 import UserNotice from './announce/_components/UserNotice';
 import AllNotices from './announce/_components/AllNotices';
 
 export default function Home() {
-  const { user } = useAuth();
-
-  console.log(user);
-
-  useEffect(() => {
-    const getUserData = async () => {
-      if (!user) return;
-      try {
-        const response = await getUserInfo(user.id);
-        console.log('유저 정보:', response.data);
-      } catch (error) {
-        console.error('유저 정보 가져오기 실패:', error);
-      }
-    };
-    const getTEst = async () => {
-      try {
-        const response2 = await getNotices(0, 100);
-        console.log('공고전체', response2.data);
-      } catch (error) {
-        console.log(error);
-      }
-    };
-    getUserData();
-    getTEst();
-  }, [user]);
-
   return (
     <div>
       <Header />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,7 +1,39 @@
+'use client';
+
+import { useEffect } from 'react';
 import Header from './_components/header';
 import DetailPostCard from './_components/PostCard/DetailPostCard';
+import { useAuth } from './_hooks/useAuth';
+import { getUserInfo } from './_api/worker_api';
+import { getNotices } from './_api/announce_api';
 
 export default function Home() {
+  const { user } = useAuth();
+
+  console.log(user);
+
+  useEffect(() => {
+    const getUserData = async () => {
+      if (!user) return;
+      try {
+        const response = await getUserInfo(user.id);
+        console.log('유저 정보:', response.data);
+      } catch (error) {
+        console.error('유저 정보 가져오기 실패:', error);
+      }
+    };
+    const getTEst = async () => {
+      try {
+        const response2 = await getNotices();
+        console.log('공고전체', response2.data);
+      } catch (error) {
+        console.log(error);
+      }
+    };
+    getUserData();
+    getTEst();
+  }, [user]);
+
   return (
     <div>
       <Header />

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,18 +1,11 @@
-import PostCard from './_components/PostCard/PostCard';
+import Header from './_components/header';
+import DetailPostCard from './_components/PostCard/DetailPostCard';
 
 export default function Home() {
   return (
     <div>
-      <PostCard
-        address1='어흥시 냐옹구'
-        name='가게이름가게이름가게이름'
-        startsAt='2023-01-04 15:00~18:00'
-        workhour='3'
-        isPast={true}
-        originalHourlyPay={5000}
-        percent={50}
-        imageUrl='https://images.unsplash.com/photo-1513360371669-4adf3dd7dff8?w=500&auto=format&fit=crop&q=60&ixlib=rb-4.0.3&ixid=M3wxMjA3fDB8MHxzZWFyY2h8MTh8fCVFQSVCMyVBMCVFQyU5NiU5MSVFQyU5RCVCNHxlbnwwfHwwfHx8MA%3D%3D'
-      />
+      <Header />
+      <DetailPostCard />
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,13 @@
 'use client';
 
 import { useEffect } from 'react';
-import Header from './_components/header';
-import DetailPostCard from './_components/PostCard/DetailPostCard';
+import Header from './_components/Header';
 import { useAuth } from './_hooks/useAuth';
 import { getUserInfo } from './_api/worker_api';
 import { getNotices } from './_api/announce_api';
+import Footer from './_components/Footer';
+import UserNotice from './announce/_components/UserNotice';
+import AllNotices from './announce/_components/AllNotices';
 
 export default function Home() {
   const { user } = useAuth();
@@ -24,7 +26,7 @@ export default function Home() {
     };
     const getTEst = async () => {
       try {
-        const response2 = await getNotices();
+        const response2 = await getNotices(0, 100);
         console.log('공고전체', response2.data);
       } catch (error) {
         console.log(error);
@@ -37,7 +39,9 @@ export default function Home() {
   return (
     <div>
       <Header />
-      <DetailPostCard />
+      <UserNotice />
+      <AllNotices />
+      <Footer />
     </div>
   );
 }


### PR DESCRIPTION
### 이슈 번호

close #114 
close #127 

### 작업 사항 요약

- 메인페이지 작업했습니다.
- api 에서 날짜가 "2025-02-02T00:00:00.000Z" 이런식으로 와서 포맷팅하는 커스텀훅 만들었습니다.
- 맞춤공고 페이지 줄어들었을떄 터치는 되는데 드래그가 안먹어서 드래그하는 함수 커스텀훅 만들었습니다.
- 포스트카드 props 관련하여 자잘하게 수정하였습니다.
- 상세페이지에서 쓰는 커다란 포스트카드 디테일포스트카드로 통합했습니다.  V1, V2 대신 이거 하나로 쓰시면됩니다.
- 메인페이지 각종 필터링 작업했습니다.
- 상세필터에 필요한 props와 함수 추가했습니다.
- 드롭다운에 필요한 props 추가했습니다.
- 페이지네이션에 현재 페이지 감지하는 로직 추가했습니다.
- 버튼과 뱃지의 borderd 스타일의 배경이 투명색이었던것을 white로 수정하였습니다.
- NoticeContext가 추가되었습니다. 공고전체목록을 가져와서 저장하는 용도로 사용합니다.


### 이어서 작업할 내용
- 공고상세
- 가까운순필터

.
