### PR TITLE
각 페이지 별 리다이렉팅 코드 추가

### DIFF
--- a/src/app/announce/edit/page.tsx
+++ b/src/app/announce/edit/page.tsx
@@ -14,9 +14,11 @@ import Modal from '@/app/_components/Modal';
 import useModal from '@/app/_hooks/useModal';
 import { updateShopNotice } from '@/app/_api/owner_api';
 import { getShopNoticeDetail } from '@/app/_api/announce_api';
+import { useAuth } from '@/app/_hooks/useAuth';
 
 const EditAnnounce = () => {
   const router = useRouter();
+  const { user } = useAuth();
   const searchParams = useSearchParams();
   const shopId = searchParams.get('shopId');
   const noticeId = searchParams.get('noticeId') || '';
@@ -32,6 +34,7 @@ const EditAnnounce = () => {
   });
 
   useEffect(() => {
+    if (user?.shop.item.id !== shopId) router.replace('/');
     if (!shopId || !noticeId) return;
 
     const fetchAnnounceInfo = async () => {

--- a/src/app/announce/post/page.tsx
+++ b/src/app/announce/post/page.tsx
@@ -14,9 +14,11 @@ import Modal from '@/app/_components/Modal';
 import useModal from '@/app/_hooks/useModal';
 import { createShopNotice } from '@/app/_api/owner_api';
 import Loading from '@/app/_components/Loding';
+import { useAuth } from '@/app/_hooks/useAuth';
 
 const PostAnnounce = () => {
   const router = useRouter();
+  const { user } = useAuth();
   const searchParams = useSearchParams();
   const shopId = searchParams.get('shopId');
   const { isOpen, openModal, closeModal } = useModal();
@@ -30,6 +32,8 @@ const PostAnnounce = () => {
   } = useForm<ownerNoticeRequest>({
     mode: 'all',
   });
+
+  if (user?.shop.item.id !== shopId) router.replace('/');
 
   const onSubmit = async (data: ownerNoticeRequest) => {
     if (!shopId) {

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -30,7 +30,9 @@ const Login = () => {
   });
   const [loading, setLoading] = useState(false);
   const router = useRouter();
-  const { loginSave } = useAuth();
+  const { loginSave, user } = useAuth();
+
+  if (user) router.replace('/');
 
   const onSubmit: SubmitHandler<RegisterRequest> = async (data) => {
     setLoading(true); // 로딩 시작

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -12,9 +12,11 @@ import { tableConfig, WorkerData } from '../_config/tableConfig';
 import { ProfileData } from './_type/type';
 import { useAuth } from '../_hooks/useAuth';
 import Loading from '../_components/Loding';
+import { useRouter } from 'next/navigation';
 
 const ProfilePage = () => {
   const { user } = useAuth();
+  const router = useRouter();
   // 상태 관리
   const [profileStatus, setProfileStatus] = useState(false);
   const [applicationStatus, setApplicationStatus] = useState(false);
@@ -28,7 +30,6 @@ const ProfilePage = () => {
   const itemsPerPage = 5;
 
   const user_id = user?.id || null;
-
   useEffect(() => {
     const fetchProfileData = async () => {
       try {
@@ -36,7 +37,7 @@ const ProfilePage = () => {
 
         const userInfoResponse = await getUserInfo(user_id!); // user_id는 null이 아님
         const userInfo = userInfoResponse.data.item;
-
+        if (user?.type === 'employer') router.replace('/');
         if (userInfo) {
           const { name, email, type, phone, address, bio } = userInfo;
 

--- a/src/app/profile/post/[id]/page.tsx
+++ b/src/app/profile/post/[id]/page.tsx
@@ -15,6 +15,7 @@ import { LOCATIONS } from '@/app/_constants/constants';
 import { getUserInfo, updateUserInfo } from '@/app/_api/worker_api';
 import Link from 'next/link';
 import Loading from '@/app/_components/Loding';
+import { useAuth } from '@/app/_hooks/useAuth';
 
 interface FormData {
   name: string;
@@ -24,6 +25,7 @@ interface FormData {
 }
 
 const ProfilePost = () => {
+  const { user } = useAuth();
   const router = useRouter();
   const { id } = useParams();
   const user_id = id as string;
@@ -50,6 +52,8 @@ const ProfilePost = () => {
   useEffect(() => {
     const fetchUserData = async () => {
       try {
+        if (!user_id) router.replace('/');
+        if (user?.type === 'employer') router.replace('/');
         const response = await getUserInfo(user_id);
         const userInfo = response.data.item;
 

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -12,8 +12,10 @@ import { register as registerApi } from '../_api/auth_api';
 import Modal from '../_components/Modal';
 import { useRouter } from 'next/navigation';
 import Loading from '../_components/Loding';
+import { useAuth } from '../_hooks/useAuth';
 
 const SignUp = () => {
+  const { user } = useAuth();
   const {
     register,
     handleSubmit,
@@ -38,6 +40,8 @@ const SignUp = () => {
   const password = watch('password');
   const [loading, setLoading] = useState(false);
   const router = useRouter();
+
+  if (user) router.replace('/');
 
   const onSubmit: SubmitHandler<RegisterRequest> = async (data) => {
     setLoading(true); // 로딩 시작

--- a/src/app/store/detail/page.tsx
+++ b/src/app/store/detail/page.tsx
@@ -11,7 +11,7 @@ import { getUserInfo } from '@/app/_api/worker_api';
 import { getShopNotices } from '@/app/_api/announce_api';
 import PostCard from '@/app/_components/PostCard/PostCard';
 import Loading from '@/app/_components/Loding';
-
+import { useRouter } from 'next/navigation';
 
 interface StoreData {
   id: string;
@@ -26,6 +26,7 @@ interface StoreData {
 
 const StoreDetailPage: React.FC = () => {
   const { user } = useAuth();
+  const router = useRouter();
   const [storeStatus, setStoreStatus] = useState<boolean>(false);
   const [announcementStatus, setAnnouncementStatus] = useState<boolean>(false);
   const [storeData, setStoreData] = useState<StoreData | null>(null);
@@ -36,6 +37,7 @@ const StoreDetailPage: React.FC = () => {
   const userId = user?.id;
 
   useEffect(() => {
+    if (user?.type === 'employee') router.replace('/');
     if (userId) {
       const fetchData = async () => {
         try {

--- a/src/app/store/edit/[id]/page.tsx
+++ b/src/app/store/edit/[id]/page.tsx
@@ -17,9 +17,11 @@ import useModal from '@/app/_hooks/useModal';
 import { CATEGORIES, LOCATIONS } from '@/app/_constants/constants';
 import { getShopInfo, updateShopInfo } from '@/app/_api/owner_api';
 import Loading from '@/app/_components/Loding';
+import { useAuth } from '@/app/_hooks/useAuth';
 
 const EditStore = () => {
   const router = useRouter();
+  const { user } = useAuth();
   const { id } = useParams();
   const shopId = id as string;
   const { isOpen, openModal, closeModal } = useModal();
@@ -40,6 +42,7 @@ const EditStore = () => {
   const imageUrl: string = watch('imageUrl');
 
   useEffect(() => {
+    if (user?.shop.item.id !== shopId) router.replace('/');
     if (!shopId) return;
 
     const fetchShopInfo = async () => {

--- a/src/app/store/post/page.tsx
+++ b/src/app/store/post/page.tsx
@@ -17,9 +17,11 @@ import useModal from '@/app/_hooks/useModal';
 import { CATEGORIES, LOCATIONS } from '@/app/_constants/constants';
 import { registerShop } from '@/app/_api/owner_api';
 import Loading from '@/app/_components/Loding';
+import { useAuth } from '@/app/_hooks/useAuth';
 
 const PostStore = () => {
   const router = useRouter();
+  const { user } = useAuth();
   const { isOpen, openModal, closeModal } = useModal();
   const [shopId, setShopId] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
@@ -37,7 +39,7 @@ const PostStore = () => {
   const imageUrl: string = watch('imageUrl');
 
   const onImageChange = (image: string) => setValue('imageUrl', image);
-
+  if (user?.type === 'employee') router.replace('/');
   const onImageDelete = () => {
     if (imageUrl) URL.revokeObjectURL(imageUrl);
     setValue('imageUrl', '');


### PR DESCRIPTION
### 이슈 번호

close #160 

### 작업 사항 요약

- 로그인 페이지 : 유저 정보가 있으면 루트 페이지로 이동
- 회원가입 페이지 : 유저 정보가 있으면 루트 페이지로 이동
- 내 프로필 상세 페이지 : 유저 타입이 employer 이면 루트 페이지로 이동
- 내 프로필 등록(수정) 페이지 : 유저 타입이 employer 이거나 userId가 일치하지 않으면 루트 페이지로 이동
- 공고 등록 페이지 : shopid가 일치하지 않으면 루트 페이지로 이동
- 공고 수정 페이지 : shopid가 일치하지 않으면 루트 페이지로 이동
- 내 가게 상세 페이지 : 유저 타입이 employee 이면 루트 페이지로 이동
- 내 가게 등록 페이지 : 유저 타입이 employee 이면 루트 페이지로 이동
- 내 가게 수정 페이지 : 유저 타입이 employee 이거나 shopId가 일치하지 않으면 루트 페이지로 이동
